### PR TITLE
Add support to open the online message documentation as quick fix action

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -260,8 +260,8 @@ def code_action(params: lsp.CodeActionParams) -> List[lsp.CodeAction]:
 
 
 def open_documentation(
-        _: workspace.Document, diagnostics: List[lsp.Diagnostic]
-    ) -> List[lsp.CodeAction]:
+    _: workspace.Document, diagnostics: List[lsp.Diagnostic]
+) -> List[lsp.CodeAction]:
     """Open an embedded simple browser window with the good/bad examples for this message."""
     return [
         _command_quick_fix(

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -17,6 +17,14 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 # Save the working directory used when loading this module
 SERVER_CWD = os.getcwd()
 CWD_LOCK = threading.Lock()
+CATEGORIES = {
+    "F": "fatal",
+    "E": "error",
+    "W": "warning",
+    "C": "convention",
+    "R": "refactor",
+    "I": "information",
+}
 
 
 def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> Union[List[Any], Tuple[Any]]:
@@ -24,6 +32,11 @@ def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> Union[List[Any], Tupl
     if isinstance(content, (list, tuple)):
         return content
     return [content]
+
+
+def get_message_category(code: str) -> Optional[str]:
+    """Get the full name of the message category."""
+    return CATEGORIES.get(code[0].upper())
 
 
 # pylint: disable-next=consider-using-generator

--- a/src/test/python_tests/test_code_actions.py
+++ b/src/test/python_tests/test_code_actions.py
@@ -82,58 +82,122 @@ def _expected_organize_imports_command():
 def test_command_code_action(code, contents, command):
     """Tests for code actions which run a command."""
     with utils.python_file(contents, TEST_FILE_PATH.parent) as temp_file:
-        uri = utils.as_uri(os.fspath(temp_file))
+        diagnostics, actual_code_actions = _get_diagnostics_and_code_actions_for_file(
+            temp_file, contents, code
+        )
 
-        actual = {}
-        with session.LspSession() as ls_session:
-            ls_session.initialize()
+        actual_code_specific_actions = _remove_generic_actions(actual_code_actions)
 
-            done = Event()
+        expected = [
+            {
+                "title": command["title"],
+                "kind": "quickfix",
+                "diagnostics": [d],
+                "command": command,
+            }
+            for d in diagnostics
+        ]
 
-            def _handler(params):
-                nonlocal actual
-                actual = params
-                done.set()
+        assert_that(actual_code_specific_actions, is_(expected))
 
-            ls_session.set_notification_callback(session.PUBLISH_DIAGNOSTICS, _handler)
 
-            ls_session.notify_did_open(
-                {
-                    "textDocument": {
-                        "uri": uri,
-                        "languageId": "python",
-                        "version": 1,
-                        "text": contents,
-                    }
+@pytest.mark.parametrize(
+    ("code", "contents", "uri"),
+    [
+        (
+            "E1300:bad-format-character",
+            "print('%s %z' % ('hello', 'world'))",
+            "error/bad-format-character.html"
+        ),
+        (
+            "W0129:assert-on-string-literal",
+            "assert 'foo'",
+            "warning/assert-on-string-literal.html"
+        ),
+        (
+            "C0303:trailing-whitespace",
+            "x =  1    \ny = 1\n",
+            "convention/trailing-whitespace.html"
+        ),
+    ]
+)
+def test_documentation_action(code, contents, uri):
+    """Tests that for messages a code action linking to the online documentation exists"""
+    with utils.python_file(contents, TEST_FILE_PATH.parent) as temp_file:
+        diagnostics, actual_code_actions = _get_diagnostics_and_code_actions_for_file(
+            temp_file, contents, code
+        )
+
+        command = {
+            "title": f"Pylint: Open documentation for {code}",
+            "command": "simpleBrowser.show",
+            "arguments": [f"https://pylint.readthedocs.io/en/latest/user_guide/messages/{uri}"]
+        }
+
+        expected = [
+            {
+                "title": command["title"],
+                "kind": "quickfix",
+                "diagnostics": [d],
+                "command": command,
+            }
+            for d in diagnostics
+        ]
+
+        assert_that(all(e in actual_code_actions) for e in expected)
+
+
+def _get_diagnostics_and_code_actions_for_file(temp_file, contents, code):
+    uri = utils.as_uri(os.fspath(temp_file))
+
+    actual = {}
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+
+        done = Event()
+
+        def _handler(params):
+            nonlocal actual
+            actual = params
+            done.set()
+
+        ls_session.set_notification_callback(session.PUBLISH_DIAGNOSTICS, _handler)
+
+        ls_session.notify_did_open(
+            {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": "python",
+                    "version": 1,
+                    "text": contents,
                 }
-            )
+            }
+        )
 
-            # wait for some time to receive all notifications
-            done.wait(TIMEOUT)
+        # wait for some time to receive all notifications
+        done.wait(TIMEOUT)
 
-            diagnostics = [d for d in actual["diagnostics"] if d["code"] == code]
+        diagnostics = [d for d in actual["diagnostics"] if d["code"] == code]
 
-            assert_that(len(diagnostics), is_(greater_than(0)))
+        assert_that(len(diagnostics), is_(greater_than(0)))
 
-            actual_code_actions = ls_session.text_document_code_action(
-                {
-                    "textDocument": {"uri": uri},
-                    "range": {
-                        "start": {"line": 0, "character": 0},
-                        "end": {"line": 1, "character": 0},
-                    },
-                    "context": {"diagnostics": diagnostics},
-                }
-            )
+        code_actions = ls_session.text_document_code_action(
+            {
+                "textDocument": {"uri": uri},
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 1, "character": 0},
+                },
+                "context": {"diagnostics": diagnostics},
+            }
+        )
 
-            expected = [
-                {
-                    "title": command["title"],
-                    "kind": "quickfix",
-                    "diagnostics": [d],
-                    "command": command,
-                }
-                for d in diagnostics
-            ]
+        return diagnostics, code_actions
 
-        assert_that(actual_code_actions, is_(expected))
+
+def _remove_generic_actions(code_actions):
+    """Remove all code actions that are not specific to a single message."""
+    return [
+        action for action in code_actions
+        if "Open documentation" not in action["title"]
+    ]

--- a/src/test/python_tests/test_code_actions.py
+++ b/src/test/python_tests/test_code_actions.py
@@ -107,19 +107,19 @@ def test_command_code_action(code, contents, command):
         (
             "E1300:bad-format-character",
             "print('%s %z' % ('hello', 'world'))",
-            "error/bad-format-character.html"
+            "error/bad-format-character.html",
         ),
         (
             "W0129:assert-on-string-literal",
             "assert 'foo'",
-            "warning/assert-on-string-literal.html"
+            "warning/assert-on-string-literal.html",
         ),
         (
             "C0303:trailing-whitespace",
             "x =  1    \ny = 1\n",
-            "convention/trailing-whitespace.html"
+            "convention/trailing-whitespace.html",
         ),
-    ]
+    ],
 )
 def test_documentation_action(code, contents, uri):
     """Tests that for messages a code action linking to the online documentation exists"""
@@ -131,7 +131,9 @@ def test_documentation_action(code, contents, uri):
         command = {
             "title": f"Pylint: Open documentation for {code}",
             "command": "simpleBrowser.show",
-            "arguments": [f"https://pylint.readthedocs.io/en/latest/user_guide/messages/{uri}"]
+            "arguments": [
+                f"https://pylint.readthedocs.io/en/latest/user_guide/messages/{uri}"
+            ],
         }
 
         expected = [
@@ -198,6 +200,5 @@ def _get_diagnostics_and_code_actions_for_file(temp_file, contents, code):
 def _remove_generic_actions(code_actions):
     """Remove all code actions that are not specific to a single message."""
     return [
-        action for action in code_actions
-        if "Open documentation" not in action["title"]
+        action for action in code_actions if "Open documentation" not in action["title"]
     ]

--- a/src/test/python_tests/test_code_actions.py
+++ b/src/test/python_tests/test_code_actions.py
@@ -82,123 +82,58 @@ def _expected_organize_imports_command():
 def test_command_code_action(code, contents, command):
     """Tests for code actions which run a command."""
     with utils.python_file(contents, TEST_FILE_PATH.parent) as temp_file:
-        diagnostics, actual_code_actions = _get_diagnostics_and_code_actions_for_file(
-            temp_file, contents, code
-        )
+        uri = utils.as_uri(os.fspath(temp_file))
 
-        actual_code_specific_actions = _remove_generic_actions(actual_code_actions)
+        actual = {}
+        with session.LspSession() as ls_session:
+            ls_session.initialize()
 
-        expected = [
-            {
-                "title": command["title"],
-                "kind": "quickfix",
-                "diagnostics": [d],
-                "command": command,
-            }
-            for d in diagnostics
-        ]
+            done = Event()
 
-        assert_that(actual_code_specific_actions, is_(expected))
+            def _handler(params):
+                nonlocal actual
+                actual = params
+                done.set()
 
+            ls_session.set_notification_callback(session.PUBLISH_DIAGNOSTICS, _handler)
 
-@pytest.mark.parametrize(
-    ("code", "contents", "uri"),
-    [
-        (
-            "E1300:bad-format-character",
-            "print('%s %z' % ('hello', 'world'))",
-            "error/bad-format-character.html",
-        ),
-        (
-            "W0129:assert-on-string-literal",
-            "assert 'foo'",
-            "warning/assert-on-string-literal.html",
-        ),
-        (
-            "C0303:trailing-whitespace",
-            "x =  1    \ny = 1\n",
-            "convention/trailing-whitespace.html",
-        ),
-    ],
-)
-def test_documentation_action(code, contents, uri):
-    """Tests that for messages a code action linking to the online documentation exists"""
-    with utils.python_file(contents, TEST_FILE_PATH.parent) as temp_file:
-        diagnostics, actual_code_actions = _get_diagnostics_and_code_actions_for_file(
-            temp_file, contents, code
-        )
-
-        command = {
-            "title": f"Pylint: Open documentation for {code}",
-            "command": "simpleBrowser.show",
-            "arguments": [
-                f"https://pylint.readthedocs.io/en/latest/user_guide/messages/{uri}"
-            ],
-        }
-
-        expected = [
-            {
-                "title": command["title"],
-                "kind": "quickfix",
-                "diagnostics": [d],
-                "command": command,
-            }
-            for d in diagnostics
-        ]
-
-        assert_that(all(e in actual_code_actions) for e in expected)
-
-
-def _get_diagnostics_and_code_actions_for_file(temp_file, contents, code):
-    uri = utils.as_uri(os.fspath(temp_file))
-
-    actual = {}
-    with session.LspSession() as ls_session:
-        ls_session.initialize()
-
-        done = Event()
-
-        def _handler(params):
-            nonlocal actual
-            actual = params
-            done.set()
-
-        ls_session.set_notification_callback(session.PUBLISH_DIAGNOSTICS, _handler)
-
-        ls_session.notify_did_open(
-            {
-                "textDocument": {
-                    "uri": uri,
-                    "languageId": "python",
-                    "version": 1,
-                    "text": contents,
+            ls_session.notify_did_open(
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": "python",
+                        "version": 1,
+                        "text": contents,
+                    }
                 }
-            }
-        )
+            )
 
-        # wait for some time to receive all notifications
-        done.wait(TIMEOUT)
+            # wait for some time to receive all notifications
+            done.wait(TIMEOUT)
 
-        diagnostics = [d for d in actual["diagnostics"] if d["code"] == code]
+            diagnostics = [d for d in actual["diagnostics"] if d["code"] == code]
 
-        assert_that(len(diagnostics), is_(greater_than(0)))
+            assert_that(len(diagnostics), is_(greater_than(0)))
 
-        code_actions = ls_session.text_document_code_action(
-            {
-                "textDocument": {"uri": uri},
-                "range": {
-                    "start": {"line": 0, "character": 0},
-                    "end": {"line": 1, "character": 0},
-                },
-                "context": {"diagnostics": diagnostics},
-            }
-        )
+            actual_code_actions = ls_session.text_document_code_action(
+                {
+                    "textDocument": {"uri": uri},
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 1, "character": 0},
+                    },
+                    "context": {"diagnostics": diagnostics},
+                }
+            )
 
-        return diagnostics, code_actions
+            expected = [
+                {
+                    "title": command["title"],
+                    "kind": "quickfix",
+                    "diagnostics": [d],
+                    "command": command,
+                }
+                for d in diagnostics
+            ]
 
-
-def _remove_generic_actions(code_actions):
-    """Remove all code actions that are not specific to a single message."""
-    return [
-        action for action in code_actions if "Open documentation" not in action["title"]
-    ]
+        assert_that(actual_code_actions, is_(expected))

--- a/src/test/python_tests/test_linting.py
+++ b/src/test/python_tests/test_linting.py
@@ -16,6 +16,7 @@ TEST_FILE_PATH = constants.TEST_DATA / "sample1" / "sample.py"
 TEST_FILE_URI = utils.as_uri(str(TEST_FILE_PATH))
 LINTER = utils.get_server_info_defaults()
 TIMEOUT = 10  # 10 seconds
+DOCUMENTATION_HOME = "https://pylint.readthedocs.io/en/latest/user_guide/messages"
 
 
 def test_publish_diagnostics_on_open():
@@ -60,6 +61,9 @@ def test_publish_diagnostics_on_open():
                 "message": "Missing module docstring",
                 "severity": 3,
                 "code": "C0114:missing-module-docstring",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/convention/missing-module-docstring.html"
+                },
                 "source": LINTER["name"],
             },
             {
@@ -73,6 +77,9 @@ def test_publish_diagnostics_on_open():
                 "message": "Undefined variable 'x'",
                 "severity": 1,
                 "code": "E0602:undefined-variable",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/error/undefined-variable.html"
+                },
                 "source": LINTER["name"],
             },
             {
@@ -86,6 +93,9 @@ def test_publish_diagnostics_on_open():
                 "message": "Unused import sys",
                 "severity": 2,
                 "code": "W0611:unused-import",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/warning/unused-import.html"
+                },
                 "source": LINTER["name"],
             },
         ],
@@ -136,6 +146,9 @@ def test_publish_diagnostics_on_save():
                 "message": "Missing module docstring",
                 "severity": 3,
                 "code": "C0114:missing-module-docstring",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/convention/missing-module-docstring.html"
+                },
                 "source": LINTER["name"],
             },
             {
@@ -149,6 +162,9 @@ def test_publish_diagnostics_on_save():
                 "message": "Undefined variable 'x'",
                 "severity": 1,
                 "code": "E0602:undefined-variable",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/error/undefined-variable.html"
+                },
                 "source": LINTER["name"],
             },
             {
@@ -162,6 +178,9 @@ def test_publish_diagnostics_on_save():
                 "message": "Unused import sys",
                 "severity": 2,
                 "code": "W0611:unused-import",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/warning/unused-import.html"
+                },
                 "source": LINTER["name"],
             },
         ],
@@ -273,6 +292,9 @@ def test_severity_setting(lint_code):
                 "message": "Missing module docstring",
                 "severity": 3,
                 "code": "C0114:missing-module-docstring",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/convention/missing-module-docstring.html"
+                },
                 "source": LINTER["name"],
             },
             {
@@ -286,6 +308,9 @@ def test_severity_setting(lint_code):
                 "message": "Undefined variable 'x'",
                 "severity": 1,
                 "code": "E0602:undefined-variable",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/error/undefined-variable.html"
+                },
                 "source": LINTER["name"],
             },
             {
@@ -299,6 +324,9 @@ def test_severity_setting(lint_code):
                 "message": "Unused import sys",
                 "severity": 1,
                 "code": "W0611:unused-import",
+                "codeDescription": {
+                    "href": f"{DOCUMENTATION_HOME}/warning/unused-import.html"
+                },
                 "source": LINTER["name"],
             },
         ],


### PR DESCRIPTION
The Pylint community put in a lot of work to document the messages with good /  bad code examples and optionally additional information (see https://github.com/PyCQA/pylint/issues/5953). 

Now that the majority of messages are covered (and the uncovered ones have at least [placeholders](https://pylint.readthedocs.io/en/latest/user_guide/messages/convention/bad-file-encoding.html)), I think it would be really nice if users of `vscode-pylint` could directly open up this documentation in VS Code.

This PR adds a new quick fix code action that is available for every message and allows to open up the corresponding link in the online documentation for the respective message in a `SimpleBrowser` view:

![image](https://user-images.githubusercontent.com/3929834/224502085-4b48e413-6688-478e-8424-20faf5dcc2fe.png)

Let me know what you think!