### PR TITLE
Fix lint on change setting description

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
                 },
                 "pylint.lintOnChange": {
                     "default": false,
-                    "description": "%settings.onChange.description%",
+                    "description": "%settings.lintOnChange.description%",
                     "scope": "machine",
                     "type": "boolean",
                     "tags": [


### PR DESCRIPTION
This is to fix this:

![image](https://github.com/microsoft/vscode-pylint/assets/45497113/185d673c-70e3-45df-a507-f564a7316f4e)
