### PR TITLE
Create removePy3.7

### DIFF
--- a/.github/workflows/removePy3.7
+++ b/.github/workflows/removePy3.7
@@ -1,0 +1,127 @@
+name: PR Validation
+
+on:
+  pull_request:
+
+env:
+  NODE_VERSION: 16.17.0
+  TEST_RESULTS_DIRECTORY: .
+  # Force a path with spaces and unicode chars to test extension works in these scenarios
+  special-working-directory: './🐍 🐛'
+  special-working-directory-relative: '🐍 🐛'
+
+jobs:
+  build-vsix:
+    name: Create VSIX
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build VSIX
+        uses: ./.github/actions/build-vsix
+        with:
+          node_version: ${{ env.NODE_VERSION}}
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Lint
+        uses: ./.github/actions/lint
+        with:
+          node_version: ${{ env.NODE_VERSION }}
+
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ${{ env.special-working-directory }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python: ['3.8', '3.9', '3.10', '3.11']  # Remove '3.7' from here
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.special-working-directory-relative }}
+
+      # Install bundled libs using 3.8 (or another supported version) even though you test it on other versions.
+      - name: Use Python 3.8 (or another supported version)
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'  # Use a supported version here
+
+      - name: Update pip, install wheel and nox
+        run: python -m pip install -U pip wheel nox
+        shell: bash
+
+      # This will install libraries to a target directory.
+      - name: Install bundled python libraries
+        run: python -m nox --session install_bundled_libs
+        shell: bash
+
+      # Now that the bundle is installed to target using python 3.8 (or another supported version)
+      # switch back the python we want to test with
+      - name: Use Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
+      # The new python may not have nox so install it again
+      - name: Update pip, install wheel and nox (again)
+        run: python -m pip install -U pip wheel nox
+        shell: bash
+
+      - name: Run tests
+        run: python -m nox --session tests
+        shell: bash
+
+      - name: Validate README.md
+        run: python -m nox --session validate_readme
+        shell: bash
+
+  ts-tests:
+    name: TypeScript Tests
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: ${{ env.special-working-directory }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.special-working-directory-relative }}
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: ${{ env.special-working-directory-relative }}/package-lock.json
+
+      - name: Install Node dependencies
+        run: npm ci
+        shell: bash
+
+      - name: Compile TS tests
+        run: npm run pretest
+        shell: bash
+
+      - name: Run TS tests
+        uses: GabrielBB/xvfb-action@v1.6
+        with:
+          run: npm run tests
+          working-directory: ${{ env.special-working-directory }}


### PR DESCRIPTION
I've removed Python 3.7 from the matrix section in the tests job, and the comments to reflect the changes. Now, the workflow will only test against Python versions 3.8 and later

Resolves: #394