### PR TITLE
Fix for code action performance issue with pylint

### DIFF
--- a/src/test/python_tests/test_code_actions.py
+++ b/src/test/python_tests/test_code_actions.py
@@ -316,8 +316,6 @@ def test_edit_code_action(code, contents, new_text):
             actual_code_action = ls_session.code_action_resolve(actual_code_actions[0])
 
             changes = actual_code_action["edit"]["documentChanges"]
-            text_document = changes[0]["textDocument"]
-            text_range = changes[0]["edits"][0]["range"]
             expected = [
                 {
                     "title": f"{LINTER}: Run autofix code action",
@@ -326,10 +324,10 @@ def test_edit_code_action(code, contents, new_text):
                     "edit": {
                         "documentChanges": [
                             {
-                                "textDocument": text_document,
+                                "textDocument": changes[0]["textDocument"],
                                 "edits": [
                                     {
-                                        "range": text_range,
+                                        "range": changes[0]["edits"][0]["range"],
                                         "newText": new_text,
                                     }
                                 ],

--- a/src/test/python_tests/test_code_actions.py
+++ b/src/test/python_tests/test_code_actions.py
@@ -307,12 +307,17 @@ def test_edit_code_action(code, contents, new_text):
                     "context": {"diagnostics": diagnostics},
                 }
             )
-            text_document = actual_code_actions[0]["edit"]["documentChanges"][0][
-                "textDocument"
-            ]
-            text_range = actual_code_actions[0]["edit"]["documentChanges"][0]["edits"][
-                0
-            ]["range"]
+
+            assert_that(
+                all("edit" not in action for action in actual_code_actions),
+                is_(True),
+            )
+
+            actual_code_action = ls_session.code_action_resolve(actual_code_actions[0])
+
+            changes = actual_code_action["edit"]["documentChanges"]
+            text_document = changes[0]["textDocument"]
+            text_range = changes[0]["edits"][0]["range"]
             expected = [
                 {
                     "title": f"{LINTER}: Run autofix code action",
@@ -336,6 +341,6 @@ def test_edit_code_action(code, contents, new_text):
             ]
 
         assert_that(
-            actual_code_actions[0]["edit"]["documentChanges"],
+            actual_code_action["edit"]["documentChanges"],
             is_(expected[0]["edit"]["documentChanges"]),
         )


### PR DESCRIPTION
potential fix for https://github.com/microsoft/vscode-pylint/issues/454

The fix is to enable code action resolve. So, on code action request we only tell VS Code that there are code actions available (by setting `edit` to `None`). We don't calculate the edits needed during the code actions request. We do this later when the code action is applies using the code action resolve request. 