### PR TITLE
add bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,60 @@
+---
+name: Bug Report
+about: Create an issue for a bug
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+<!-- Hello! Thank you for submitting a bug to our repo. Our users and their bug reports are essential to our development process.
+Before you submit an issue:
+1. Please search for the bug in existing issues on the repo. Search using keywords or error messages and check both `open` and `closed` issues.
+2. Try setting your log level to trace and look at the logs in more detail, as there may be more information there. If not, then these trace logs are part
+of the bug report below! (see directions on how to set and access these logs)
+
+Thank you!
+
+Steps to set log level to trace and view:
+1. Open the Command Palette via Press Ctrl+Shift+P (Windows/Linux) or Cmd+Shift+P (macOS).
+2. Find the Command to Set Log Level: Type 'Developer: Set Log Level', select `trace`.
+3. Open the Output panel by going to View > Output, or by using the shortcut Ctrl+Shift+U on Windows/Linux or Cmd+Shift+U on macOS.
+4. Select `Python` from the dropdown.
+5. Your logs should now be shown! Try rerunning the failing command again now that logs are set to `trace` to look at all information.
+ -->
+
+## Diagnostic Data
+- Python version (& distribution if applicable, e.g., Anaconda): <!-- ADD YOUR ANSWER HERE -->
+- Type of virtual environment used (e.g., conda, venv, virtualenv, etc.): <!-- ADD YOUR ANSWER HERE -->
+- Operating system (and version): <!-- ADD YOUR ANSWER HERE -->
+- Version of tool extension you are using: <!-- ADD YOUR ANSWER HERE -->
+
+## Behaviour
+### Expected Behavior
+<!-- What did you expect to happen? -->
+
+### Actual Behavior
+<!-- What actually happened? -->
+
+## Reproduction Steps:
+<!-- How can we reproduce the bug? Please be as detailed as possible so we can help with your bug faster! -->
+
+## Logs:
+<details>
+  <summary>Click here for detailed logs</summary>
+  <!-- Paste your logs here -->
+</details>
+
+## Outcome When Attempting Debugging Steps:
+<!-- Please attempt running the tool from the command line and see the result, as our extension ultimately calls the tool and reports back this information.
+Steps:
+1. Use the steps at the top of this page `Steps to set log level to trace and view` to get to the Python logs.
+2. Search in your logs for keywords like "command", "running", and you will find a line that shows the exact command we run.
+3. Run this command in your command line, and see if it works from there!
+If it works from your command line and not the extension, this is likely an extension bug; if it doesn't work in your command line, debug there. -->
+Did running it from the command line work? <!-- ADD YOUR ANSWER HERE -->
+
+## Extra Details
+<!-- Optional: Anything else which might be useful?
+This may include:
+- What other Python-related extensions are you using?
+- What does your project structure look like? -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,17 +10,8 @@ assignees: ''
 Before you submit an issue:
 1. Please search for the bug in existing issues on the repo. Search using keywords or error messages and check both `open` and `closed` issues.
 2. Try setting your log level to trace and look at the logs in more detail, as there may be more information there. If not, then these trace logs are part
-of the bug report below! (see directions on how to set and access these logs)
-
-Thank you!
-
-Steps to set log level to trace and view:
-1. Open the Command Palette via Press Ctrl+Shift+P (Windows/Linux) or Cmd+Shift+P (macOS).
-2. Find the Command to Set Log Level: Type 'Developer: Set Log Level', select `trace`.
-3. Open the Output panel by going to View > Output, or by using the shortcut Ctrl+Shift+U on Windows/Linux or Cmd+Shift+U on macOS.
-4. Select `Pylint` from the dropdown.
-5. Your logs should now be shown! Try rerunning the failing command again now that logs are set to `trace` to look at all information.
- -->
+of the bug report below! (see directions on how to set and access these logs in the `Logs` section below.)
+Thank you!-->
 
 ## Diagnostic Data
 - Python version (& distribution if applicable, e.g., Anaconda): <!-- ADD YOUR ANSWER HERE -->
@@ -39,6 +30,13 @@ Steps to set log level to trace and view:
 <!-- How can we reproduce the bug? Please be as detailed as possible so we can help with your bug faster! -->
 
 ## Logs:
+<!--
+Steps to set log level to trace and view:
+1. Open the Command Palette via Press Ctrl+Shift+P (Windows/Linux) or Cmd+Shift+P (macOS).
+2. Find the Command to Set Log Level: Type 'Developer: Set Log Level', select `trace`.
+3. Open the Output panel by going to View > Output, or by using the shortcut Ctrl+Shift+U on Windows/Linux or Cmd+Shift+U on macOS.
+4. Select `Pylint` from the dropdown.
+5. Your logs should now be shown! Try rerunning the failing command again now that logs are set to `trace` to look at all information. -->
 <details>
   <summary>Click here for detailed logs</summary>
   <!-- Paste your logs here -->
@@ -57,4 +55,7 @@ Did running it from the command line work? <!-- ADD YOUR ANSWER HERE -->
 <!-- Optional: Anything else which might be useful?
 This may include:
 - What other Python-related extensions are you using?
-- What does your project structure look like? -->
+- What does your project structure look like?
+- Are you working in a multiroot workspace?
+- Where is the config file for the current tool?
+- Any extra settings from your workspace or user settings.json files? -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Create an issue for a bug
+about: Create an issue for a bug in the Pylint tools extension for VS Code.
 title: ''
 labels: 'bug'
 assignees: ''
@@ -18,7 +18,7 @@ Steps to set log level to trace and view:
 1. Open the Command Palette via Press Ctrl+Shift+P (Windows/Linux) or Cmd+Shift+P (macOS).
 2. Find the Command to Set Log Level: Type 'Developer: Set Log Level', select `trace`.
 3. Open the Output panel by going to View > Output, or by using the shortcut Ctrl+Shift+U on Windows/Linux or Cmd+Shift+U on macOS.
-4. Select `Python` from the dropdown.
+4. Select `Pylint` from the dropdown.
 5. Your logs should now be shown! Try rerunning the failing command again now that logs are set to `trace` to look at all information.
  -->
 
@@ -47,7 +47,7 @@ Steps to set log level to trace and view:
 ## Outcome When Attempting Debugging Steps:
 <!-- Please attempt running the tool from the command line and see the result, as our extension ultimately calls the tool and reports back this information.
 Steps:
-1. Use the steps at the top of this page `Steps to set log level to trace and view` to get to the Python logs.
+1. Use the steps at the top of this page `Steps to set log level to trace and view` to get to the `Pylint` logs.
 2. Search in your logs for keywords like "command", "running", and you will find a line that shows the exact command we run.
 3. Run this command in your command line, and see if it works from there!
 If it works from your command line and not the extension, this is likely an extension bug; if it doesn't work in your command line, debug there. -->


### PR DESCRIPTION
lmk your thoughts on the directions and format here. I went and explained a generic way to look for a command in logs which could be used for tooling extensions but we can clarify per tool if you have a specific output line that they should look for 