### PR TITLE
Update dependabot to final version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,33 @@
 version: 2
 updates:
+  # NPM dependencies are updated weekly, minor updates are grouped (1 PR "npm-minor-patch").
   - package-ecosystem: 'npm'
+    labels:
+      - 'dependencies'
+      - 'debt'
+      - 'no-changelog'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      npm-minor-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/vscode'
+      - dependency-name: '@types/node'
+      - dependency-name: 'vscode-languageclient'
 
+  # Python dependencies are updated weekly, minor updates are grouped (1 PR "pip-minor-patch").
+  # The no-changelog label is NOT added here
   - package-ecosystem: 'pip'
+    labels:
+      - 'dependencies'
+      - 'debt'
     directory: '/'
     schedule:
       interval: 'weekly'
@@ -21,27 +39,13 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
 
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    open-pull-requests-limit: 10
-    groups:
-      github-actions-minor-patch:
-        patterns:
-          - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
-
+  # Python test dependencies are updated weekly, minor updates are grouped (1 PR "pip-test-minor-patch").
   - package-ecosystem: 'pip'
+    labels:
+      - 'dependencies'
+      - 'debt'
+      - 'no-changelog'
     directory: '/src/test/python_tests'
     schedule:
       interval: 'weekly'
@@ -53,6 +57,21 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-major']
+
+  # GitHub Actions dependencies are updated weekly, minor updates are grouped (1 PR "github-actions-minor-patch").
+  - package-ecosystem: 'github-actions'
+    labels:
+      - 'dependencies'
+      - 'debt'
+      - 'no-changelog'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -16,6 +16,6 @@ jobs:
       - name: 'PR impact specified'
         uses: mheap/github-action-required-labels@v5
         with:
-          mode: exactly
+          mode: minimum
           count: 1
           labels: 'bug, debt, feature-request, no-changelog, dependencies'


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve how dependency updates are managed and labeled, and makes a minor adjustment to the pull request label workflow. The main changes group minor and patch updates for various ecosystems, add or adjust labels, and tweak the required PR label logic.

**Dependabot configuration improvements:**

* Grouped minor and patch updates for NPM, Python, Python test, and GitHub Actions dependencies into single pull requests per ecosystem, making updates easier to manage. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R3-R30) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L24-L58)
* Added consistent labels (`dependencies`, `debt`, `no-changelog`) to Dependabot PRs for better tracking and triage, with some differences for Python dependencies. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R3-R30) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L24-L58)
* Updated ignore rules to exclude specific dependencies from updates instead of all major version bumps, giving finer control over what gets updated.

**Workflow configuration:**

* Changed the PR label requirement in `.github/workflows/pr-labels.yml` from `exactly` one required label to a `minimum` of one label, allowing more flexibility in labeling pull requests.