### PR TITLE
Disable CI trigger in stable pipeline

### DIFF
--- a/build/azure-devdiv-pipeline.stable.yml
+++ b/build/azure-devdiv-pipeline.stable.yml
@@ -1,8 +1,11 @@
 name: Publish Release
-trigger:
-  branches:
-    include:
-      - refs/tags/*
+trigger: none
+#   branches:
+#     include:
+#       - release*
+#   tags:
+#     include: ['*']
+pr: none
 
 resources:
   repositories:


### PR DESCRIPTION
Set trigger and pr to none in azure-devdiv-pipeline.stable.yml, matching vscode-python-debugger's format.