### PR TITLE
Add PR creation skill for Copilot

### DIFF
--- a/.github/instructions/pr-instructions.md
+++ b/.github/instructions/pr-instructions.md
@@ -8,3 +8,4 @@ When creating pull requests, always include one of these labels:
 
 - `bug` — for bug fixes
 - `debt` — for technical debt improvements
+- `feature-request` — for new feature implementations


### PR DESCRIPTION
Add .github/instructions/pr.instructions.md to ensure PRs always include a bug or debt label.