### PR TITLE
Sync with template: Fix duplicate server handlers on concurrent restarts

### DIFF
--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -91,9 +91,9 @@ export async function restartServer(
         } catch (ex) {
             traceError(`Server: Stop failed: ${ex}`);
         }
-        _disposables.forEach((d) => d.dispose());
-        _disposables = [];
     }
+    _disposables.forEach((d) => d.dispose());
+    _disposables = [];
     updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
     const newLSClient = await createServer(workspaceSetting, serverId, serverName, outputChannel, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,6 +116,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 export async function deactivate(): Promise<void> {
     if (lsClient) {
-        await lsClient.stop();
+        try {
+            await lsClient.stop();
+        } catch (ex) {
+            traceError(`Server: Stop failed: ${ex}`);
+        }
     }
 }


### PR DESCRIPTION
- Move _disposables cleanup outside if(oldLsClient) in restartServer() so disposables are always cleaned up regardless of prior client state
- Wrap lsClient.stop() in try/catch in deactivate() to handle errors during extension deactivation gracefully

==================================================================

Generated from template https://github.com/microsoft/vscode-python-tools-extension-template/pull/259