### PR TITLE
Bump version to 2026.3.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pylint",
     "displayName": "Pylint",
     "description": "%extension.description%",
-    "version": "2025.3.0",
+    "version": "2026.3.0-dev",
     "preview": true,
     "serverInfo": {
         "name": "Pylint",


### PR DESCRIPTION
Update package.json version to 2026.3.0-dev for the 2026.3 release cycle.