### PR TITLE
Refactor: normalize_path resolve_symlinks, is_match workspace_root

### DIFF
--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -86,9 +86,12 @@ def is_same_path(file_path1: str, file_path2: str) -> bool:
         return pathlib.Path(file_path1) == pathlib.Path(file_path2)
 
 
-def normalize_path(file_path: str) -> str:
+def normalize_path(file_path: str, resolve_symlinks: bool = True) -> str:
     """Returns normalized path."""
-    return str(pathlib.Path(file_path).resolve())
+    path = pathlib.Path(file_path)
+    if resolve_symlinks:
+        path = path.resolve()
+    return str(path)
 
 
 def is_current_interpreter(executable: str) -> bool:

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -105,11 +105,37 @@ def is_stdlib_file(file_path: str) -> bool:
     return any(normalized_path.startswith(path) for path in _stdlib_paths)
 
 
-def is_match(patterns: List[str], file_path: str) -> bool:
+def _get_relative_path(file_path: str, workspace_root: str) -> str:
+    """Returns the file path relative to the workspace root.
+
+    Falls back to the original path if the workspace root is empty or
+    the paths are on different drives (Windows).
+    """
+    if not workspace_root:
+        return pathlib.Path(file_path).as_posix()
+    try:
+        return pathlib.Path(file_path).relative_to(workspace_root).as_posix()
+    except ValueError:
+        return pathlib.Path(file_path).as_posix()
+
+
+def is_match(
+    patterns: List[str],
+    file_path: str,
+    workspace_root: str = None,
+) -> bool:
     """Returns true if the file matches one of the fnmatch patterns."""
     if not patterns:
         return False
-    return any(fnmatch.fnmatch(file_path, pattern) for pattern in patterns)
+    relative_path = (
+        _get_relative_path(file_path, workspace_root) if workspace_root else file_path
+    )
+    file_name = pathlib.Path(file_path).name
+    return any(
+        fnmatch.fnmatch(relative_path, pattern)
+        or (not pattern.startswith("/") and fnmatch.fnmatch(file_name, pattern))
+        for pattern in patterns
+    )
 
 
 # pylint: disable-next=too-few-public-methods


### PR DESCRIPTION
Normalization changes for shared package extraction.

> Tracking: microsoft/vscode-pylint#773 | microsoft/vscode-python-tools-extension-template#290

- [x] **4.2d** Add `resolve_symlinks=True` param to `normalize_path()`
- [x] **4.2e** Add optional `workspace_root` param to `is_match()`

All changes backwards-compatible. Default values preserve existing behavior.