### PR TITLE
Refactor: add exit_code field to RunResult

### DIFF
--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -113,9 +113,12 @@ def is_match(patterns: List[str], file_path: str) -> bool:
 class RunResult:
     """Object to hold result from running tool."""
 
-    def __init__(self, stdout, stderr):
-        self.stdout = stdout
-        self.stderr = stderr
+    def __init__(
+        self, stdout: str, stderr: str, exit_code: Optional[Union[int, str]] = None
+    ):
+        self.stdout: str = stdout
+        self.stderr: str = stderr
+        self.exit_code: Optional[Union[int, str]] = exit_code
 
 
 class CustomIO(io.TextIOWrapper):


### PR DESCRIPTION
## Summary

Add an \xit_code\ field to the \RunResult\ class in \undled/tool/lsp_utils.py\, matching mypy's implementation pattern.

### Changes
- Added \xit_code: Optional[Union[int, str]] = None\ parameter to \RunResult.__init__\
- Added type hints to all \RunResult\ instance attributes (\stdout\, \stderr\, \xit_code\)
- Default is \None\ so all existing callers continue to work unchanged (backward-compatible)

### Context
Part of microsoft/vscode-pylint#773
Ref: microsoft/vscode-python-tools-extension-template#290