### PR TITLE
Refactor: merge vscodeapi.ts to cross-repo superset

### DIFF
--- a/src/common/vscodeapi.ts
+++ b/src/common/vscodeapi.ts
@@ -7,6 +7,7 @@ import {
     commands,
     ConfigurationScope,
     Disposable,
+    DocumentFormattingEditProvider,
     languages,
     LanguageStatusItem,
     LogOutputChannel,
@@ -46,6 +47,13 @@ export function getWorkspaceFolders(): readonly WorkspaceFolder[] {
 
 export function getWorkspaceFolder(uri: Uri): WorkspaceFolder | undefined {
     return workspace.getWorkspaceFolder(uri);
+}
+
+export function registerDocumentFormattingEditProvider(
+    selector: DocumentSelector,
+    provider: DocumentFormattingEditProvider,
+): Disposable {
+    return languages.registerDocumentFormattingEditProvider(selector, provider);
 }
 
 export function createLanguageStatusItem(id: string, selector: DocumentSelector): LanguageStatusItem {


### PR DESCRIPTION
Merges vscodeapi.ts to the superset of all 5 extension repos. Adds `registerDocumentFormattingEditProvider` export (from black). This is an unused wrapper that doesn't affect runtime behavior.

Part of #773
Ref: microsoft/vscode-python-tools-extension-template#290