### PR TITLE
test: backport shared test coverage (logging, global_defaults, stdlib_detection)

### DIFF
--- a/src/test/python_tests/test_global_defaults.py
+++ b/src/test/python_tests/test_global_defaults.py
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Unit tests for _get_global_defaults() in lsp_server.
+
+Validates that global settings are correctly read (or hardcoded) in the
+pylint extension.  Mock setup is provided by conftest.py (setup_lsp_mocks).
+"""
+
+# pylint: disable=protected-access
+import lsp_server
+
+
+def _with_global_settings(overrides, func):
+    """Run *func* with GLOBAL_SETTINGS temporarily set to *overrides*."""
+    original = lsp_server.GLOBAL_SETTINGS.copy()
+    try:
+        lsp_server.GLOBAL_SETTINGS.clear()
+        lsp_server.GLOBAL_SETTINGS.update(overrides)
+        return func()
+    finally:
+        lsp_server.GLOBAL_SETTINGS.clear()
+        lsp_server.GLOBAL_SETTINGS.update(original)
+
+
+def test_ignore_patterns_defaults_to_empty_list():
+    """_get_global_defaults() returns [] when GLOBAL_SETTINGS has no ignorePatterns."""
+    result = _with_global_settings({}, lsp_server._get_global_defaults)
+    assert result["ignorePatterns"] == []
+
+
+def test_ignore_patterns_hardcoded_empty():
+    """_get_global_defaults() always returns [] for ignorePatterns (hardcoded)."""
+    result = _with_global_settings(
+        {"ignorePatterns": ["**/vendor/**", "**/.tox/**"]},
+        lsp_server._get_global_defaults,
+    )
+    assert result["ignorePatterns"] == []
+
+
+def test_show_notifications_read_from_global_settings():
+    """_get_global_defaults() returns showNotifications from GLOBAL_SETTINGS."""
+    result = _with_global_settings(
+        {"showNotifications": "always"},
+        lsp_server._get_global_defaults,
+    )
+    assert result["showNotifications"] == "always"
+
+
+def test_import_strategy_read_from_global_settings():
+    """_get_global_defaults() returns importStrategy from GLOBAL_SETTINGS."""
+    result = _with_global_settings(
+        {"importStrategy": "fromEnvironment"},
+        lsp_server._get_global_defaults,
+    )
+    assert result["importStrategy"] == "fromEnvironment"

--- a/src/test/python_tests/test_logging.py
+++ b/src/test/python_tests/test_logging.py
@@ -1,0 +1,160 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Unit tests for the logging/notification helpers in lsp_server.
+
+Verifies the Pygls 2 window_log_message/window_show_message API and the
+LS_SHOW_NOTIFICATION gating logic for log_to_output, log_error,
+log_warning, and log_always.
+
+Mock setup is provided by conftest.py (setup_lsp_mocks).
+LSP_SERVER patching uses the ``patched_lsp_server`` fixture which restores
+originals automatically via ``unittest.mock.patch.object``.
+"""
+
+import os
+from unittest.mock import patch
+
+import lsp_server
+
+
+# ---------------------------------------------------------------------------
+# log_to_output
+# ---------------------------------------------------------------------------
+def test_log_to_output_calls_window_log_message(patched_lsp_server):
+    """log_to_output uses the Pygls 2 window_log_message API."""
+    log_mock, show_mock = patched_lsp_server
+
+    lsp_server.log_to_output("hello")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# log_error
+# ---------------------------------------------------------------------------
+def test_log_error_always_logs(patched_lsp_server):
+    """log_error always calls window_log_message regardless of notification setting."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
+        lsp_server.log_error("error occurred")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_error_shows_notification_on_error(patched_lsp_server):
+    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=onError."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
+        lsp_server.log_error("error occurred")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+def test_log_error_shows_notification_on_always(patched_lsp_server):
+    """log_error shows a notification popup when LS_SHOW_NOTIFICATION=always."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
+        lsp_server.log_error("error occurred")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# log_warning
+# ---------------------------------------------------------------------------
+def test_log_warning_no_notification_when_off(patched_lsp_server):
+    """log_warning does not show notification when LS_SHOW_NOTIFICATION=off."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_warning_no_notification_on_error_only(patched_lsp_server):
+    """log_warning does not show notification when LS_SHOW_NOTIFICATION=onError."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_warning_shows_notification_on_warning(patched_lsp_server):
+    """log_warning shows notification when LS_SHOW_NOTIFICATION=onWarning."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+def test_log_warning_shows_notification_on_always(patched_lsp_server):
+    """log_warning shows notification when LS_SHOW_NOTIFICATION=always."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
+        lsp_server.log_warning("warning message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# log_always
+# ---------------------------------------------------------------------------
+def test_log_always_no_notification_when_off(patched_lsp_server):
+    """log_always does not show notification when LS_SHOW_NOTIFICATION=off."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "off"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_always_no_notification_on_error(patched_lsp_server):
+    """log_always does not show notification when LS_SHOW_NOTIFICATION=onError."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onError"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_always_no_notification_on_warning(patched_lsp_server):
+    """log_always does not show notification when LS_SHOW_NOTIFICATION=onWarning."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "onWarning"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_not_called()
+
+
+def test_log_always_shows_notification_on_always(patched_lsp_server):
+    """log_always shows notification only when LS_SHOW_NOTIFICATION=always."""
+    log_mock, show_mock = patched_lsp_server
+
+    with patch.dict(os.environ, {"LS_SHOW_NOTIFICATION": "always"}):
+        lsp_server.log_always("info message")
+
+    log_mock.assert_called_once()
+    show_mock.assert_called_once()

--- a/src/test/python_tests/test_stdlib_detection.py
+++ b/src/test/python_tests/test_stdlib_detection.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Unit tests for stdlib/managed-path file detection in lsp_utils.
+
+Tests the ``is_stdlib_file`` helper which determines whether a file belongs
+to a Python-managed path (stdlib, site-packages, or VS Code extensions dir).
+
+Note: pylint's ``is_stdlib_file`` checks against *all* known Python paths
+(including site-packages), unlike some other extensions that exclude
+site-packages.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Add bundled tool to path (also done by conftest, but kept for standalone use)
+_BUNDLED_PATH = str(Path(__file__).parent.parent.parent.parent / "bundled" / "tool")
+if _BUNDLED_PATH not in sys.path:
+    sys.path.insert(0, _BUNDLED_PATH)
+
+from lsp_utils import is_stdlib_file  # pylint: disable=wrong-import-position
+
+
+def test_stdlib_file_detection():
+    """Actual stdlib files (e.g. os module) are correctly identified."""
+    os_file = os.__file__
+    assert is_stdlib_file(
+        os_file
+    ), f"os module file {os_file} should be detected as stdlib"
+
+    if hasattr(sys, "__file__"):
+        sys_file = sys.__file__
+        assert is_stdlib_file(
+            sys_file
+        ), f"sys module file {sys_file} should be detected as stdlib"
+
+
+def test_random_file_not_stdlib():
+    """Random user files are NOT identified as stdlib."""
+    with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = is_stdlib_file(tmp_path)
+        assert not result, f"Temporary file {tmp_path} should NOT be detected as stdlib"
+    finally:
+        os.unlink(tmp_path)
+
+
+def test_user_project_file_not_stdlib():
+    """A file in a user project directory is not detected as stdlib."""
+    test_file = os.path.join(os.sep, "home", "user", "my-project", "src", "main.py")
+    result = is_stdlib_file(test_file)
+    assert not result, f"User project file {test_file} should NOT be detected as stdlib"
+
+
+if __name__ == "__main__":
+    test_stdlib_file_detection()
+    test_random_file_not_stdlib()
+    test_user_project_file_not_stdlib()
+    print("All tests passed!")


### PR DESCRIPTION
Backport test files from flake8 that test shared infrastructure:
- test_logging.py: logging helpers and LS_SHOW_NOTIFICATION gating
- test_global_defaults.py: _get_global_defaults() settings reading
- test_stdlib_detection.py: stdlib/site-packages file detection
- conftest.py: shared mock fixtures for lsp_server unit tests

These tests cover shared code that exists in all repos but was only tested in flake8.

Part of microsoft/vscode-python-tools-extension-template#290