### PR TITLE
Bump version to 2026.5.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "pylint",
     "displayName": "Pylint",
     "description": "%extension.description%",
-    "version": "2026.4.0",
+    "version": "2026.5.0-dev",
     "preview": true,
     "serverInfo": {
         "name": "Pylint",


### PR DESCRIPTION
Advance main to the next pre-release development version after cutting the release/2026.4 branch.