### PR TITLE
feat: wire vscode-common-python-lsp shared package (Stage 1)

### DIFF
--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -14,7 +14,6 @@ from vscode_common_python_lsp import (
     CWD_LOCK,
     SERVER_CWD,
     CustomIO,
-    PythonFileKind,
     QuickFixRegistrationError,
     RunResult,
     as_list,

--- a/bundled/tool/lsp_utils.py
+++ b/bundled/tool/lsp_utils.py
@@ -1,27 +1,37 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-"""Utility functions and classes for use with running tools over LSP."""
+"""Utility functions and classes for use with running tools over LSP.
+
+Thin wrapper: delegates to vscode-common-python-lsp shared package,
+providing backward-compatible names used by lsp_server.py.
+"""
 
 from __future__ import annotations
 
-import contextlib
-import fnmatch
-import io
-import logging
-import os
-import os.path
-import pathlib
-import runpy
-import site
-import subprocess
-import sys
-import sysconfig
-import threading
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Optional
 
-# Save the working directory used when loading this module
-SERVER_CWD = os.getcwd()
-CWD_LOCK = threading.Lock()
+from vscode_common_python_lsp import (
+    CWD_LOCK,
+    SERVER_CWD,
+    CustomIO,
+    PythonFileKind,
+    QuickFixRegistrationError,
+    RunResult,
+    as_list,
+    change_cwd,
+    classify_python_file,
+    is_current_interpreter,
+    is_match,
+    is_same_path,
+    normalize_path,
+    redirect_io,
+    run_api,
+    run_module,
+    run_path,
+    substitute_attr,
+)
+
+# Pylint-specific message category mapping
 CATEGORIES = {
     "F": "fatal",
     "E": "error",
@@ -37,300 +47,29 @@ def get_message_category(code: str) -> Optional[str]:
     return CATEGORIES.get(code[0].upper())
 
 
-def as_list(content: Union[Any, List[Any], Tuple[Any]]) -> List[Any]:
-    """Ensures we always get a list"""
-    if isinstance(content, (list, tuple)):
-        return list(content)
-    return [content]
-
-
-def _get_sys_config_paths() -> List[str]:
-    """Returns paths from sysconfig.get_paths()."""
-    return [
-        path
-        for group, path in sysconfig.get_paths().items()
-        if group not in ["data", "platdata", "scripts"]
-    ]
-
-
-def _get_extensions_dir() -> List[str]:
-    """This is the extensions folder under ~/.vscode or ~/.vscode-server."""
-
-    # The path here is calculated relative to the tool
-    # this is because users can launch VS Code with custom
-    # extensions folder using the --extensions-dir argument
-    path = pathlib.Path(__file__).parent.parent.parent.parent
-    #                              ^     bundled  ^  extensions
-    #                            tool        <extension>
-    if path.name == "extensions":
-        return [os.fspath(path)]
-    return []
-
-
-_stdlib_paths = set(
-    str(pathlib.Path(p).resolve())
-    for p in (
-        as_list(site.getsitepackages())
-        + as_list(site.getusersitepackages())
-        + _get_sys_config_paths()
-        + _get_extensions_dir()
-    )
-)
-
-
-def is_same_path(file_path1: str, file_path2: str) -> bool:
-    """Returns true if two paths are the same, resolving symlinks."""
-    try:
-        return pathlib.Path(file_path1).resolve() == pathlib.Path(file_path2).resolve()
-    except OSError:
-        return pathlib.Path(file_path1) == pathlib.Path(file_path2)
-
-
-def normalize_path(file_path: str, resolve_symlinks: bool = True) -> str:
-    """Returns normalized path."""
-    path = pathlib.Path(file_path)
-    if resolve_symlinks:
-        path = path.resolve()
-    return str(path)
-
-
-def is_current_interpreter(executable: str) -> bool:
-    """Returns true if the executable path is same as the current interpreter."""
-    return is_same_path(executable, sys.executable)
-
-
 def is_stdlib_file(file_path: str) -> bool:
-    """Return True if the file belongs to the standard library."""
-    normalized_path = str(pathlib.Path(file_path).resolve())
-    return any(normalized_path.startswith(path) for path in _stdlib_paths)
+    """Return True if the file belongs to a non-user Python path."""
+    return classify_python_file(file_path) is not None
 
 
-def _get_relative_path(file_path: str, workspace_root: str) -> str:
-    """Returns the file path relative to the workspace root.
-
-    Falls back to the original path if the workspace root is empty or
-    the paths are on different drives (Windows).
-    """
-    if not workspace_root:
-        return pathlib.Path(file_path).as_posix()
-    try:
-        return pathlib.Path(file_path).relative_to(workspace_root).as_posix()
-    except ValueError:
-        return pathlib.Path(file_path).as_posix()
-
-
-def is_match(
-    patterns: List[str],
-    file_path: str,
-    workspace_root: str = None,
-) -> bool:
-    """Returns true if the file matches one of the fnmatch patterns."""
-    if not patterns:
-        return False
-    relative_path = (
-        _get_relative_path(file_path, workspace_root) if workspace_root else file_path
-    )
-    file_name = pathlib.Path(file_path).name
-    return any(
-        fnmatch.fnmatch(relative_path, pattern)
-        or (not pattern.startswith("/") and fnmatch.fnmatch(file_name, pattern))
-        for pattern in patterns
-    )
-
-
-# pylint: disable-next=too-few-public-methods
-class RunResult:
-    """Object to hold result from running tool."""
-
-    def __init__(
-        self, stdout: str, stderr: str, exit_code: Optional[Union[int, str]] = None
-    ):
-        self.stdout: str = stdout
-        self.stderr: str = stderr
-        self.exit_code: Optional[Union[int, str]] = exit_code
-
-
-class CustomIO(io.TextIOWrapper):
-    """Custom stream object to replace stdio."""
-
-    name = None
-
-    def __init__(self, name, encoding="utf-8", newline=None):
-        self._buffer = io.BytesIO()
-        self._buffer.name = name
-        super().__init__(self._buffer, encoding=encoding, newline=newline)
-
-    def close(self):
-        """Provide this close method which is used by some tools."""
-        # This is intentionally empty.
-
-    def get_value(self) -> str:
-        """Returns value from the buffer as string."""
-        self.seek(0)
-        return self.read()
-
-
-@contextlib.contextmanager
-def substitute_attr(obj: Any, attribute: str, new_value: Any):
-    """Manage object attributes context when using runpy.run_module()."""
-    old_value = getattr(obj, attribute)
-    setattr(obj, attribute, new_value)
-    yield
-    setattr(obj, attribute, old_value)
-
-
-@contextlib.contextmanager
-def redirect_io(stream: str, new_stream):
-    """Redirect stdio streams to a custom stream."""
-    old_stream = getattr(sys, stream)
-    setattr(sys, stream, new_stream)
-    yield
-    setattr(sys, stream, old_stream)
-
-
-@contextlib.contextmanager
-def change_cwd(new_cwd):
-    """Change working directory before running code."""
-    try:
-        os.chdir(new_cwd)
-    except OSError as e:
-        logging.warning(
-            "Failed to change directory to %r, running in %r instead: %s",
-            new_cwd,
-            SERVER_CWD,
-            e,
-        )
-        yield
-        return
-    try:
-        yield
-    finally:
-        os.chdir(SERVER_CWD)
-
-
-class LSPServerError(Exception):
-    """Base class for errors while working with LSP server."""
-
-
-class QuickFixRegistrationError(LSPServerError):
-    """Represents error while registering code actions quick fixes."""
-
-    def __init__(self, diagnostic_code):
-        super().__init__()
-        self.diagnostic_code = diagnostic_code
-
-    def __repr__(self):
-        return f'Quick Fix for "{self.diagnostic_code}" is already registered.'
-
-
-def _run_module(
-    module: str, argv: Sequence[str], use_stdin: bool, source: str = None
-) -> RunResult:
-    """Runs as a module."""
-    str_output = CustomIO("<stdout>", encoding="utf-8")
-    str_error = CustomIO("<stderr>", encoding="utf-8")
-
-    exit_code = None
-    try:
-        with substitute_attr(sys, "argv", argv):
-            with redirect_io("stdout", str_output):
-                with redirect_io("stderr", str_error):
-                    if use_stdin and source is not None:
-                        str_input = CustomIO("<stdin>", encoding="utf-8", newline="\n")
-                        with redirect_io("stdin", str_input):
-                            str_input.write(source)
-                            str_input.seek(0)
-                            runpy.run_module(module, run_name="__main__")
-                    else:
-                        runpy.run_module(module, run_name="__main__")
-    except SystemExit as ex:
-        exit_code = ex.code
-
-    return RunResult(str_output.get_value(), str_error.get_value(), exit_code)
-
-
-def run_module(
-    module: str, argv: Sequence[str], use_stdin: bool, cwd: str, source: str = None
-) -> RunResult:
-    """Runs as a module."""
-    with CWD_LOCK:
-        if is_same_path(os.getcwd(), cwd):
-            return _run_module(module, argv, use_stdin, source)
-        with change_cwd(cwd):
-            return _run_module(module, argv, use_stdin, source)
-
-
-def run_path(
-    argv: Sequence[str],
-    use_stdin: bool,
-    cwd: str,
-    source: str = None,
-    env: Optional[Dict[str, str]] = None,
-) -> RunResult:
-    """Runs as an executable."""
-    _env = os.environ.copy()
-    if env is not None:
-        _env.update(env)
-
-    if use_stdin:
-        with subprocess.Popen(
-            argv,
-            encoding="utf-8",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
-            cwd=cwd,
-            env=_env,
-        ) as process:
-            return RunResult(*process.communicate(input=source))
-    else:
-        result = subprocess.run(
-            argv,
-            encoding="utf-8",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-            cwd=cwd,
-            env=_env,
-        )
-        return RunResult(result.stdout, result.stderr)
-
-
-def run_api(
-    callback: Callable[[Sequence[str], CustomIO, CustomIO, CustomIO | None], None],
-    argv: Sequence[str],
-    use_stdin: bool,
-    cwd: str,
-    source: str = None,
-) -> RunResult:
-    """Run a API."""
-    with CWD_LOCK:
-        if is_same_path(os.getcwd(), cwd):
-            return _run_api(callback, argv, use_stdin, source)
-        with change_cwd(cwd):
-            return _run_api(callback, argv, use_stdin, source)
-
-
-def _run_api(
-    callback: Callable[[Sequence[str], CustomIO, CustomIO, CustomIO | None], None],
-    argv: Sequence[str],
-    use_stdin: bool,
-    source: str = None,
-) -> RunResult:
-    str_output = CustomIO("<stdout>", encoding="utf-8")
-    str_error = CustomIO("<stderr>", encoding="utf-8")
-
-    with contextlib.suppress(SystemExit):
-        with substitute_attr(sys, "argv", argv):
-            with redirect_io("stdout", str_output):
-                with redirect_io("stderr", str_error):
-                    if use_stdin and source is not None:
-                        str_input = CustomIO("<stdin>", encoding="utf-8", newline="\n")
-                        with redirect_io("stdin", str_input):
-                            str_input.write(source)
-                            str_input.seek(0)
-                            callback(argv, str_output, str_error, str_input)
-                    else:
-                        callback(argv, str_output, str_error)
-
-    return RunResult(str_output.get_value(), str_error.get_value())
+__all__ = [
+    "SERVER_CWD",
+    "CWD_LOCK",
+    "CATEGORIES",
+    "get_message_category",
+    "as_list",
+    "normalize_path",
+    "is_same_path",
+    "is_current_interpreter",
+    "is_stdlib_file",
+    "is_match",
+    "RunResult",
+    "CustomIO",
+    "substitute_attr",
+    "redirect_io",
+    "change_cwd",
+    "run_module",
+    "run_path",
+    "run_api",
+    "QuickFixRegistrationError",
+]

--- a/noxfile.py
+++ b/noxfile.py
@@ -116,6 +116,16 @@ def install_bundled_libs(session):
     """Installs the libraries that will be bundled with the extension."""
     session.install("wheel")
     _install_bundle(session)
+    session.install(
+        "-t",
+        "./bundled/libs",
+        "--no-cache-dir",
+        "--implementation",
+        "py",
+        "--no-deps",
+        "--upgrade",
+        "vscode-common-python-lsp==0.3.0",
+    )
 
 
 @nox.session(python="3.10")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "pylint",
-    "version": "2026.3.0-dev",
+    "version": "2026.5.0-dev",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "pylint",
-            "version": "2026.3.0-dev",
+            "version": "2026.5.0-dev",
             "license": "MIT",
             "dependencies": {
+                "@vscode/common-python-lsp": "0.2.1",
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.6",
                 "dotenv": "^17.4.0",
@@ -1252,6 +1253,24 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
+        },
+        "node_modules/@vscode/common-python-lsp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.2.1.tgz",
+            "integrity": "sha512-FNYU9DCwa4InI6bGkmALw0JcEMEytRD2hp9wz3PNZ7pV1qtVB/Uvhj3rxr0fe9S9iXB4+GPF/tiF+xVmLhGQIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=18.0.0",
+                "vscode": "^1.74.0"
+            }
         },
         "node_modules/@vscode/python-environments": {
             "version": "1.0.0",
@@ -2784,9 +2803,9 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-            "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==",
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"
@@ -8297,6 +8316,19 @@
             "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
             "dev": true
         },
+        "@vscode/common-python-lsp": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.2.1.tgz",
+            "integrity": "sha512-FNYU9DCwa4InI6bGkmALw0JcEMEytRD2hp9wz3PNZ7pV1qtVB/Uvhj3rxr0fe9S9iXB4+GPF/tiF+xVmLhGQIQ==",
+            "requires": {
+                "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
+                "@vscode/python-extension": "^1.0.6",
+                "dotenv": "^17.4.1",
+                "fs-extra": "^11.3.4",
+                "semver": "^7.7.4",
+                "vscode-languageclient": "^8.1.0"
+            }
+        },
         "@vscode/python-environments": {
             "version": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
             "integrity": "sha1-AQxJi6ysjdysdHVWlc/H3XEbHfU="
@@ -9403,9 +9435,9 @@
             }
         },
         "dotenv": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.0.tgz",
-            "integrity": "sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ=="
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+            "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
         },
         "dunder-proto": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -228,6 +228,7 @@
         ]
     },
     "dependencies": {
+        "@vscode/common-python-lsp": "0.2.1",
         "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
         "@vscode/python-extension": "^1.0.6",
         "dotenv": "^17.4.0",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as path from 'path';
+import { ToolConfig } from '@vscode/common-python-lsp';
 
 const folderName = path.basename(__dirname);
 export const EXTENSION_ROOT_DIR =
@@ -14,3 +15,45 @@ export const PYTHON_MINOR = 10;
 export const PYTHON_VERSION = `${PYTHON_MAJOR}.${PYTHON_MINOR}`;
 export const LS_SERVER_RESTART_DELAY = 1000;
 export const PYLINT_CONFIG_FILES = ['.pylintrc', 'pylintrc', 'pyproject.toml', 'setup.cfg', 'tox.ini'];
+
+export const PYLINT_TOOL_CONFIG: ToolConfig = {
+    toolId: 'pylint',
+    toolDisplayName: 'Pylint',
+    toolModule: 'pylint',
+    minimumPythonVersion: { major: PYTHON_MAJOR, minor: PYTHON_MINOR },
+    configFiles: PYLINT_CONFIG_FILES,
+    serverScript: SERVER_SCRIPT_PATH,
+    debugServerScript: DEBUG_SERVER_SCRIPT_PATH,
+    restartDelay: LS_SERVER_RESTART_DELAY,
+    pythonUtf8: true,
+    settingsDefaults: {
+        enabled: true,
+        args: [],
+        severity: {
+            convention: 'Information',
+            error: 'Error',
+            fatal: 'Error',
+            refactor: 'Hint',
+            warning: 'Warning',
+            info: 'Information',
+        },
+        path: [],
+        ignorePatterns: [],
+        importStrategy: 'useBundled',
+        showNotifications: 'off',
+        lintOnChange: false,
+    },
+    trackedSettings: [
+        'pylint.args',
+        'pylint.cwd',
+        'pylint.enabled',
+        'pylint.severity',
+        'pylint.path',
+        'pylint.interpreter',
+        'pylint.importStrategy',
+        'pylint.showNotifications',
+        'pylint.ignorePatterns',
+        'pylint.lintOnChange',
+        'python.analysis.extraPaths',
+    ],
+};

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -1,93 +1,39 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as fsapi from 'fs-extra';
-import { Disposable, env, l10n, LanguageStatusSeverity, LogOutputChannel, Uri } from 'vscode';
+import { Disposable, l10n, LanguageStatusSeverity, LogOutputChannel } from 'vscode';
 import { State } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/node';
 import {
-    LanguageClient,
-    LanguageClientOptions,
-    RevealOutputChannelOn,
-    ServerOptions,
-} from 'vscode-languageclient/node';
-import { DEBUG_SERVER_SCRIPT_PATH, SERVER_SCRIPT_PATH } from './constants';
-import { getEnvFileVars } from './envFile';
-import { traceError, traceInfo, traceVerbose } from './logging';
-import { getDebuggerPath } from './python';
-import { getExtensionSettings, getGlobalSettings, ISettings, isLintOnChangeEnabled } from './settings';
-import { getLSClientTraceLevel, getDocumentSelector } from './utilities';
+    IBaseSettings,
+    getServerCwd as _getServerCwd,
+    restartServer as _restartServer,
+} from '@vscode/common-python-lsp';
+import { PYLINT_TOOL_CONFIG } from './constants';
+import { traceError, traceVerbose } from './logging';
+import { ISettings, isLintOnChangeEnabled } from './settings';
+import { getLSClientTraceLevel } from './utilities';
 import { updateScore, updateStatus } from './status';
-import { getWorkspaceFolder } from './vscodeapi';
 
-export type IInitOptions = { settings: ISettings[]; globalSettings: ISettings };
+export type { IInitOptions } from '@vscode/common-python-lsp';
 
-async function createServer(
-    settings: ISettings,
-    serverId: string,
-    serverName: string,
-    outputChannel: LogOutputChannel,
-    initializationOptions: IInitOptions,
-): Promise<LanguageClient> {
-    const command = settings.interpreter[0];
-    const cwd = settings.cwd === '${fileDirname}' ? Uri.parse(settings.workspace).fsPath : settings.cwd;
+// Lazy-initialized PythonEnvironmentsProvider
+import { PythonEnvironmentsProvider } from '@vscode/common-python-lsp';
 
-    // Set debugger path needed for debugging Python code.
-    const newEnv = { ...process.env };
-
-    // Load environment variables from the envFile (python.envFile setting)
-    const workspaceUri = Uri.parse(settings.workspace);
-    const workspaceFolder = getWorkspaceFolder(workspaceUri);
-    if (workspaceFolder) {
-        const envFileVars = await getEnvFileVars(workspaceFolder);
-        Object.assign(newEnv, envFileVars);
+let _provider: PythonEnvironmentsProvider | undefined;
+export function getPythonProvider(): PythonEnvironmentsProvider {
+    if (!_provider) {
+        _provider = new PythonEnvironmentsProvider(PYLINT_TOOL_CONFIG);
     }
+    return _provider;
+}
 
-    const debuggerPath = await getDebuggerPath();
-    const isDebugScript = await fsapi.pathExists(DEBUG_SERVER_SCRIPT_PATH);
-    if (newEnv.USE_DEBUGPY && debuggerPath) {
-        newEnv.DEBUGPY_PATH = debuggerPath;
-    } else {
-        newEnv.USE_DEBUGPY = 'False';
-    }
-
-    // Set import strategy
-    newEnv.LS_IMPORT_STRATEGY = settings.importStrategy;
-
-    // Set notification type
-    newEnv.LS_SHOW_NOTIFICATION = settings.showNotifications;
-
-    newEnv.PYTHONUTF8 = '1';
-
-    if (isLintOnChangeEnabled(serverId)) {
-        newEnv.VSCODE_PYLINT_LINT_ON_CHANGE = '1';
-    }
-
-    const args =
-        newEnv.USE_DEBUGPY === 'False' || !isDebugScript
-            ? settings.interpreter.slice(1).concat([SERVER_SCRIPT_PATH])
-            : settings.interpreter.slice(1).concat([DEBUG_SERVER_SCRIPT_PATH]);
-    traceInfo(`Server run command: ${[command, ...args].join(' ')}`);
-
-    const serverOptions: ServerOptions = {
-        command,
-        args,
-        options: { cwd, env: newEnv },
-    };
-
-    // Options to control the language client
-    const clientOptions: LanguageClientOptions = {
-        // Register the server for Python documents
-        documentSelector: getDocumentSelector(),
-        outputChannel: outputChannel,
-        traceOutputChannel: outputChannel,
-        revealOutputChannelOn: RevealOutputChannelOn.Never,
-        initializationOptions,
-    };
-
-    return new LanguageClient(serverId, serverName, serverOptions, clientOptions);
+export function getServerCwd(settings: ISettings): string {
+    return _getServerCwd(settings as unknown as IBaseSettings);
 }
 
 let _disposables: Disposable[] = [];
+
 export async function restartServer(
     workspaceSetting: ISettings,
     serverId: string,
@@ -95,24 +41,46 @@ export async function restartServer(
     outputChannel: LogOutputChannel,
     oldLsClient?: LanguageClient,
 ): Promise<LanguageClient | undefined> {
-    if (oldLsClient) {
-        traceInfo(`Server: Stop requested`);
+    _disposables.forEach((d) => {
         try {
-            await oldLsClient.stop();
+            d.dispose();
         } catch (ex) {
-            traceError(`Server: Stop failed: ${ex}`);
+            traceError(`Failed to dispose: ${ex}`);
         }
-    }
-    _disposables.forEach((d) => d.dispose());
+    });
     _disposables = [];
     updateStatus(undefined, LanguageStatusSeverity.Information, true);
 
-    const newLSClient = await createServer(workspaceSetting, serverId, serverName, outputChannel, {
-        settings: await getExtensionSettings(serverId, true),
-        globalSettings: await getGlobalSettings(serverId, false),
-    });
+    // Build extra env vars including VSCODE_PYLINT_LINT_ON_CHANGE
+    const toolConfig = { ...PYLINT_TOOL_CONFIG };
+    if (isLintOnChangeEnabled(serverId)) {
+        toolConfig.extraEnvVars = {
+            ...toolConfig.extraEnvVars,
+            VSCODE_PYLINT_LINT_ON_CHANGE: '1',
+        };
+    }
 
-    traceInfo(`Server: Start requested.`);
+    const result = await _restartServer(
+        {
+            settings: workspaceSetting as unknown as IBaseSettings,
+            serverId,
+            serverName,
+            outputChannel,
+            toolConfig,
+            pythonProvider: getPythonProvider(),
+        },
+        oldLsClient,
+    );
+
+    _disposables = result.disposables;
+    const newLSClient = result.client;
+
+    if (!newLSClient) {
+        updateStatus(l10n.t('Server failed to start.'), LanguageStatusSeverity.Error);
+        return undefined;
+    }
+
+    // Register pylint-specific notification handlers
     _disposables.push(
         newLSClient.onNotification('pylint/score', (params: { uri: string; score: number }) => {
             updateScore(params.uri, params.score);
@@ -125,7 +93,7 @@ export async function restartServer(
     );
     _disposables.push(
         newLSClient.onNotification('pylint/lintingFailed', (params: { uri: string }) => {
-            updateScore(params.uri, -1); // Show -1 score if linting failed, as we won't have a valid score to display.
+            updateScore(params.uri, -1);
         }),
     );
     _disposables.push(
@@ -144,15 +112,9 @@ export async function restartServer(
             }
         }),
     );
-    try {
-        await newLSClient.start();
-    } catch (ex) {
-        updateStatus(l10n.t('Server failed to start.'), LanguageStatusSeverity.Error);
-        traceError(`Server: Start failed: ${ex}`);
-        return undefined;
-    }
 
     try {
+        const { env } = await import('vscode');
         await newLSClient.setTrace(getLSClientTraceLevel(outputChannel.logLevel, env.logLevel));
     } catch (ex) {
         traceError(`Server: Failed to set trace level: ${ex}`);

--- a/src/test/python_tests/test_change_cwd.py
+++ b/src/test/python_tests/test_change_cwd.py
@@ -31,7 +31,10 @@ def test_change_cwd_permission_error_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=PermissionError("Access denied")):
+    with patch(
+        "vscode_common_python_lsp.context.os.chdir",
+        side_effect=PermissionError("Access denied"),
+    ):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/restricted/path"):
                 body_executed = True

--- a/src/test/python_tests/test_change_cwd.py
+++ b/src/test/python_tests/test_change_cwd.py
@@ -54,7 +54,10 @@ def test_change_cwd_oserror_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=OSError("Some OS error")):
+    with patch(
+        "vscode_common_python_lsp.context.os.chdir",
+        side_effect=OSError("Some OS error"),
+    ):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/inaccessible"):
                 body_executed = True

--- a/src/test/python_tests/test_change_cwd.py
+++ b/src/test/python_tests/test_change_cwd.py
@@ -31,7 +31,7 @@ def test_change_cwd_permission_error_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("lsp_utils.os.chdir", side_effect=PermissionError("Access denied")):
+    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=PermissionError("Access denied")):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/restricted/path"):
                 body_executed = True
@@ -51,7 +51,7 @@ def test_change_cwd_oserror_does_not_crash(caplog):
     original_cwd = os.getcwd()
     body_executed = False
 
-    with patch("lsp_utils.os.chdir", side_effect=OSError("Some OS error")):
+    with patch("vscode_common_python_lsp.context.os.chdir", side_effect=OSError("Some OS error")):
         with caplog.at_level(logging.WARNING):
             with lsp_utils.change_cwd("/inaccessible"):
                 body_executed = True


### PR DESCRIPTION
## Summary

Wires the `vscode-common-python-lsp` shared package into the extension (Stage 1).

## Changes

- **Python**: Replace `lsp_utils.py` with thin wrapper delegating to shared package
- **TypeScript**: Add `ToolConfig` to constants.ts, replace `server.ts` with shared package delegation
- **Dependencies**: Add shared package (npm `@vscode/common-python-lsp@0.2.1` + PyPI `vscode-common-python-lsp==0.3.0` bundled)
- **Tests**: Update `test_change_cwd.py` patch targets for new module structure

Zero behavioral changes. All tests pass.