### PR TITLE
refactor: use shared package APIs for settings and lsp_server

### DIFF
--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -44,7 +44,6 @@ update_sys_path(
 # Imports needed for the language server goes below this.
 # **********************************************************
 # pylint: disable=wrong-import-position,import-error
-import lsp_jsonrpc as jsonrpc
 import lsp_notebook as notebook
 import lsp_utils as utils
 from lsprotocol import types as lsp
@@ -54,19 +53,15 @@ from pygls.workspace import TextDocument
 from vscode_common_python_lsp import (
     QuickFixRegistrationError,
     RunResult,
+    ToolServer,
+    ToolServerConfig,
     is_current_interpreter,
     is_match,
-    normalize_path,
-    run_module,
-    run_path,
-    substitute_attr,
     update_environ_path,
 )
 
 update_environ_path()
 
-WORKSPACE_SETTINGS = {}
-GLOBAL_SETTINGS = {}
 RUNNER = pathlib.Path(__file__).parent / "runner.py"
 
 MAX_WORKERS = 5
@@ -82,6 +77,32 @@ LSP_SERVER = LanguageServer(
     max_workers=MAX_WORKERS,
     notebook_document_sync=notebook.NOTEBOOK_SYNC_OPTIONS,
 )
+
+PYLINT_CONFIG = ToolServerConfig(
+    tool_module="pylint",
+    tool_display="Pylint",
+    tool_args=["--reports=n", "--output-format=json2"],
+    min_version="2.14.0",
+    runner_script=str(RUNNER),
+    default_settings={
+        "enabled": True,
+        "severity": {
+            "convention": "Information",
+            "error": "Error",
+            "fatal": "Error",
+            "refactor": "Hint",
+            "warning": "Warning",
+            "info": "Information",
+        },
+        "ignorePatterns": [],
+        "extraPaths": [],
+    },
+)
+
+tool_server = ToolServer(PYLINT_CONFIG, server=LSP_SERVER)
+
+WORKSPACE_SETTINGS = tool_server.workspace_settings
+GLOBAL_SETTINGS = tool_server.global_settings
 
 
 def _get_document_path(document: str) -> str:
@@ -111,15 +132,15 @@ def _get_document_path(document: str) -> str:
 # **********************************************************
 # Tool specific code goes below this.
 # **********************************************************
-TOOL_MODULE = "pylint"
-TOOL_DISPLAY = "Pylint"
+TOOL_MODULE = PYLINT_CONFIG.tool_module
+TOOL_DISPLAY = PYLINT_CONFIG.tool_display
 DOCUMENTATION_HOME = "https://pylint.readthedocs.io/en/latest/user_guide/messages"
 
 # Default arguments always passed to pylint.
-TOOL_ARGS = ["--reports=n", "--output-format=json2"]
+TOOL_ARGS = PYLINT_CONFIG.tool_args
 
 # Minimum version of pylint supported.
-MIN_VERSION = "2.14.0"
+MIN_VERSION = PYLINT_CONFIG.min_version
 
 # **********************************************************
 # Linting features start here
@@ -697,42 +718,31 @@ def _create_workspace_edits(
 @LSP_SERVER.feature(lsp.INITIALIZE)
 def initialize(params: lsp.InitializeParams) -> None:
     """LSP handler for initialize request."""
-    log_to_output(f"CWD Server: {os.getcwd()}")
+    tool_server.apply_settings(params)
+    settings = (params.initialization_options or {}).get("settings")
+
     import_strategy = os.getenv("LS_IMPORT_STRATEGY", "useBundled")
     update_sys_path(os.getcwd(), import_strategy)
 
-    GLOBAL_SETTINGS.update(**params.initialization_options.get("globalSettings", {}))
-
-    settings = params.initialization_options["settings"]
-    _update_workspace_settings(settings)
-    log_to_output(
-        f"Settings used to run Server:\r\n{json.dumps(settings, indent=4, ensure_ascii=False)}\r\n"
-    )
-    log_to_output(
-        f"Global settings:\r\n{json.dumps(GLOBAL_SETTINGS, indent=4, ensure_ascii=False)}\r\n"
-    )
-
     # Add extra paths to sys.path
-    setting = _get_settings_by_path(pathlib.Path(os.getcwd()))
+    setting = tool_server.get_settings_by_path(pathlib.Path(os.getcwd()))
     for extra in setting.get("extraPaths", []):
         update_sys_path(extra, import_strategy)
 
-    paths = "\r\n   ".join(sys.path)
-    log_to_output(f"sys.path used to run Server:\r\n   {paths}")
-
+    tool_server.log_startup_info(settings)
     _log_version_info()
 
 
 @LSP_SERVER.feature(lsp.EXIT)
 def on_exit(_params: Optional[Any] = None) -> None:
     """Handle clean up on exit."""
-    jsonrpc.shutdown_json_rpc()
+    tool_server.handle_exit()
 
 
 @LSP_SERVER.feature(lsp.SHUTDOWN)
 def on_shutdown(_params: Optional[Any] = None) -> None:
     """Handle clean up on shutdown."""
-    jsonrpc.shutdown_json_rpc()
+    tool_server.handle_shutdown()
 
 
 def _log_version_info() -> None:
@@ -782,152 +792,36 @@ def _log_version_info() -> None:
 # Internal functional and settings management APIs.
 # *****************************************************
 def _get_global_defaults():
-    return {
-        "enabled": GLOBAL_SETTINGS.get("enabled", True),
-        "path": GLOBAL_SETTINGS.get("path", []),
-        "interpreter": GLOBAL_SETTINGS.get("interpreter", [sys.executable]),
-        "args": GLOBAL_SETTINGS.get("args", []),
-        "severity": GLOBAL_SETTINGS.get(
-            "severity",
-            {
-                "convention": "Information",
-                "error": "Error",
-                "fatal": "Error",
-                "refactor": "Hint",
-                "warning": "Warning",
-                "info": "Information",
-            },
-        ),
-        "ignorePatterns": [],
-        "importStrategy": GLOBAL_SETTINGS.get("importStrategy", "useBundled"),
-        "showNotifications": GLOBAL_SETTINGS.get("showNotifications", "off"),
-        "extraPaths": GLOBAL_SETTINGS.get("extraPaths", []),
-    }
+    defaults = tool_server.get_global_defaults()
+    # ignorePatterns is always hardcoded to [] — the client resolves it
+    # before sending per-workspace settings, so the global default must
+    # never reflect user-supplied values.
+    defaults["ignorePatterns"] = []
+    return defaults
 
 
 def _update_workspace_settings(settings):
-    if not settings:
-        key = normalize_path(os.getcwd())
-        WORKSPACE_SETTINGS[key] = {
-            "cwd": key,
-            "workspaceFS": key,
-            "workspace": uris.from_fs_path(key),
-            **_get_global_defaults(),
-        }
-        return
-
-    for setting in settings:
-        key = normalize_path(uris.to_fs_path(setting["workspace"]))
-        WORKSPACE_SETTINGS[key] = {
-            **setting,
-            "workspaceFS": key,
-        }
+    tool_server.update_workspace_settings(settings)
 
 
 def _get_settings_by_path(file_path: pathlib.Path):
-    workspaces = {s["workspaceFS"] for s in WORKSPACE_SETTINGS.values()}
-
-    while file_path != file_path.parent:
-        str_file_path = normalize_path(file_path)
-        if str_file_path in workspaces:
-            return WORKSPACE_SETTINGS[str_file_path]
-        file_path = file_path.parent
-
-    setting_values = list(WORKSPACE_SETTINGS.values())
-    return setting_values[0]
+    return tool_server.get_settings_by_path(file_path)
 
 
 def _get_document_key(document: TextDocument):
-    if WORKSPACE_SETTINGS:
-        document_workspace = pathlib.Path(document.path)
-        workspaces = {s["workspaceFS"] for s in WORKSPACE_SETTINGS.values()}
-
-        # Find workspace settings for the given file.
-        while document_workspace != document_workspace.parent:
-            norm_path = normalize_path(document_workspace)
-            if norm_path in workspaces:
-                return norm_path
-            document_workspace = document_workspace.parent
-
-    return None
+    return tool_server.get_document_key(document)
 
 
 def _get_settings_by_document(document: TextDocument | None):
-    if document is None or document.path is None:
-        return list(WORKSPACE_SETTINGS.values())[0]
-
-    key = _get_document_key(document)
-    if key is None:
-        # This is either a non-workspace file or there is no workspace.
-        key = normalize_path(pathlib.Path(document.path).parent)
-        return {
-            "cwd": key,
-            "workspaceFS": key,
-            "workspace": uris.from_fs_path(key),
-            **_get_global_defaults(),
-        }
-
-    return WORKSPACE_SETTINGS[str(key)]
+    return tool_server.get_settings_by_document(document)
 
 
 # *****************************************************
 # Internal execution APIs.
 # *****************************************************
 def get_cwd(settings: Dict[str, Any], document: Optional[TextDocument]) -> str:
-    """Returns the working directory for running the tool.
-
-    Resolves the following VS Code file-related variable substitutions when
-    a document is available:
-
-    - ``${file}`` – absolute path of the current document.
-    - ``${fileBasename}`` – file name with extension (e.g. ``foo.py``).
-    - ``${fileBasenameNoExtension}`` – file name without extension (e.g. ``foo``).
-    - ``${fileExtname}`` – file extension including the dot (e.g. ``.py``).
-    - ``${fileDirname}`` – directory containing the current document.
-    - ``${fileDirnameBasename}`` – name of the directory containing the document.
-    - ``${relativeFile}`` – document path relative to the workspace root.
-    - ``${relativeFileDirname}`` – document directory relative to the workspace root.
-    - ``${fileWorkspaceFolder}`` – workspace root folder for the document.
-
-    Variables that do not depend on the document (``${workspaceFolder}``,
-    ``${userHome}``, ``${cwd}``) are pre-resolved by the TypeScript client.
-
-    If no document is available and the value contains any unresolvable
-    file-variable, the workspace root is returned as a fallback.
-
-    See https://code.visualstudio.com/docs/reference/variables-reference
-    """
-    cwd = settings.get("cwd", settings["workspaceFS"])
-
-    workspace_fs = settings["workspaceFS"]
-
-    if document and document.path:
-        file_path = document.path
-        file_dir = os.path.dirname(file_path)
-        file_basename = os.path.basename(file_path)
-        file_stem, file_ext = os.path.splitext(file_basename)
-
-        substitutions = {
-            "${file}": file_path,
-            "${fileBasename}": file_basename,
-            "${fileBasenameNoExtension}": file_stem,
-            "${fileExtname}": file_ext,
-            "${fileDirname}": file_dir,
-            "${fileDirnameBasename}": os.path.basename(file_dir),
-            "${relativeFile}": os.path.relpath(file_path, workspace_fs),
-            "${relativeFileDirname}": os.path.relpath(file_dir, workspace_fs),
-            "${fileWorkspaceFolder}": workspace_fs,
-        }
-
-        for token, value in substitutions.items():
-            cwd = cwd.replace(token, value)
-    else:
-        # Without a document we cannot resolve file-related variables.
-        # Fall back to workspace root if any remain.
-        if "${file" in cwd or "${relativeFile" in cwd:
-            cwd = workspace_fs
-
-    return cwd
+    """Returns the working directory for running the tool."""
+    return tool_server.get_cwd(settings, document)
 
 
 # pylint: disable=too-many-branches,too-many-statements
@@ -966,27 +860,21 @@ def _run_tool_on_document(
         return None
 
     code_workspace = settings["workspaceFS"]
-    cwd = get_cwd(settings, document)
+    cwd = tool_server.get_cwd(settings, document)
 
-    use_path = False
-    use_rpc = False
     if settings["path"]:
-        # 'path' setting takes priority over everything.
-        use_path = True
-        argv = settings["path"]
+        mode = "path"
+        argv = list(settings["path"])
     elif settings["interpreter"] and not is_current_interpreter(
         settings["interpreter"][0]
     ):
-        # If there is a different interpreter set use JSON-RPC to the subprocess
-        # running under that interpreter.
+        mode = "rpc"
         argv = [TOOL_MODULE]
-        use_rpc = True
     else:
-        # if the interpreter is same as the interpreter running this
-        # process then run as module.
+        mode = "module"
         argv = [TOOL_MODULE]
 
-    argv += TOOL_ARGS + settings["args"] + extra_args
+    argv += TOOL_ARGS + settings["args"] + list(extra_args)
 
     # pygls normalizes the path to lowercase on windows, but we need to resolve the
     # correct capitalization to avoid https://github.com/pylint-dev/pylint/issues/10137
@@ -998,65 +886,30 @@ def _run_tool_on_document(
         argv += [resolved_path]
 
     env = None
-    if use_path or use_rpc:
+    if mode in ("path", "rpc"):
         # for path and rpc modes we need to set PYTHONPATH, for module or API mode
         # we would have already set the extra paths in the initialize handler.
         env = _get_updated_env(settings)
 
-    if use_path:
-        # This mode is used when running executables.
-        log_to_output(" ".join(argv))
-        log_to_output(f"CWD Server: {cwd}")
-        result = run_path(
-            argv=argv,
-            use_stdin=use_stdin,
-            cwd=cwd,
-            source=document.source.replace("\r\n", "\n"),
-            env=env,
-        )
-        if result.stderr:
-            log_to_output(result.stderr)
-            if any(kw in result.stderr.lower() for kw in _STDERR_ERROR_KEYWORDS):
-                log_warning(result.stderr)
-    elif use_rpc:
-        # This mode is used if the interpreter running this server is different from
-        # the interpreter used for running this server.
-        log_to_output(" ".join(settings["interpreter"] + ["-m"] + argv))
-        log_to_output(f"CWD Linter: {cwd}")
+    source = document.source
+    if mode == "path" and use_stdin:
+        source = source.replace("\r\n", "\n")
 
-        result = jsonrpc.run_over_json_rpc(
-            workspace=code_workspace,
-            interpreter=settings["interpreter"],
-            module=TOOL_MODULE,
-            argv=argv,
-            use_stdin=use_stdin,
-            cwd=cwd,
-            source=document.source,
-            env=env,
-        )
-        result = _to_run_result_with_logging(result)
-    else:
-        # In this mode the tool is run as a module in the same process as the language server.
-        log_to_output(" ".join([sys.executable, "-m"] + argv))
-        log_to_output(f"CWD Linter: {cwd}")
-        # This is needed to preserve sys.path, in cases where the tool modifies
-        # sys.path and that might not work for this scenario next time around.
-        with substitute_attr(sys, "path", [""] + sys.path[:]):
-            try:
-                result = run_module(
-                    module=TOOL_MODULE,
-                    argv=argv,
-                    use_stdin=use_stdin,
-                    cwd=cwd,
-                    source=document.source,
-                )
-            except Exception:
-                log_error(traceback.format_exc(chain=True))
-                raise
-        if result.stderr:
-            log_to_output(result.stderr)
-            if any(kw in result.stderr.lower() for kw in _STDERR_ERROR_KEYWORDS):
-                log_warning(result.stderr)
+    result = tool_server.execute_tool(
+        argv=argv,
+        mode=mode,
+        settings=settings,
+        use_stdin=use_stdin,
+        cwd=cwd,
+        workspace=code_workspace,
+        source=source,
+        env=env,
+    )
+
+    if result.stderr and any(
+        kw in result.stderr.lower() for kw in _STDERR_ERROR_KEYWORDS
+    ):
+        tool_server.log_warning(result.stderr)
 
     return result
 
@@ -1064,76 +917,42 @@ def _run_tool_on_document(
 def _run_tool(extra_args: Sequence[str], settings: Dict[str, Any]) -> RunResult:
     """Runs tool."""
     code_workspace = settings["workspaceFS"]
-    cwd = get_cwd(settings, None)
+    cwd = tool_server.get_cwd(settings, None)
 
-    use_path = False
-    use_rpc = False
     if len(settings["path"]) > 0:
-        # 'path' setting takes priority over everything.
-        use_path = True
-        argv = settings["path"]
+        mode = "path"
+        argv = list(settings["path"])
     elif len(settings["interpreter"]) > 0 and not is_current_interpreter(
         settings["interpreter"][0]
     ):
-        # If there is a different interpreter set use JSON-RPC to the subprocess
-        # running under that interpreter.
+        mode = "rpc"
         argv = [TOOL_MODULE]
-        use_rpc = True
     else:
-        # if the interpreter is same as the interpreter running this
-        # process then run as module.
+        mode = "module"
         argv = [TOOL_MODULE]
 
-    argv += extra_args
+    argv += list(extra_args)
 
     env = None
-    if use_path or use_rpc:
+    if mode in ("path", "rpc"):
         # for path and rpc modes we need to set PYTHONPATH, for module or API mode
         # we would have already set the extra paths in the initialize handler.
         env = _get_updated_env(settings)
 
-    if use_path:
-        # This mode is used when running executables.
-        log_to_output(" ".join(argv))
-        log_to_output(f"CWD Server: {cwd}")
-        result = run_path(argv=argv, use_stdin=True, cwd=cwd, env=env)
-        if result.stderr:
-            log_to_output(result.stderr)
-            if any(kw in result.stderr.lower() for kw in _STDERR_ERROR_KEYWORDS):
-                log_warning(result.stderr)
-    elif use_rpc:
-        # This mode is used if the interpreter running this server is different from
-        # the interpreter used for running this server.
-        log_to_output(" ".join(settings["interpreter"] + ["-m"] + argv))
-        log_to_output(f"CWD Linter: {cwd}")
-        result = jsonrpc.run_over_json_rpc(
-            workspace=code_workspace,
-            interpreter=settings["interpreter"],
-            module=TOOL_MODULE,
-            argv=argv,
-            use_stdin=True,
-            cwd=cwd,
-            env=env,
-        )
-        result = _to_run_result_with_logging(result)
-    else:
-        # In this mode the tool is run as a module in the same process as the language server.
-        log_to_output(" ".join([sys.executable, "-m"] + argv))
-        log_to_output(f"CWD Linter: {cwd}")
-        # This is needed to preserve sys.path, in cases where the tool modifies
-        # sys.path and that might not work for this scenario next time around.
-        with substitute_attr(sys, "path", [""] + sys.path[:]):
-            try:
-                result = run_module(
-                    module=TOOL_MODULE, argv=argv, use_stdin=True, cwd=cwd
-                )
-            except Exception:
-                log_error(traceback.format_exc(chain=True))
-                raise
-        if result.stderr:
-            log_to_output(result.stderr)
-            if any(kw in result.stderr.lower() for kw in _STDERR_ERROR_KEYWORDS):
-                log_warning(result.stderr)
+    result = tool_server.execute_tool(
+        argv=argv,
+        mode=mode,
+        settings=settings,
+        use_stdin=True,
+        cwd=cwd,
+        workspace=code_workspace,
+        env=env,
+    )
+
+    if result.stderr and any(
+        kw in result.stderr.lower() for kw in _STDERR_ERROR_KEYWORDS
+    ):
+        tool_server.log_warning(result.stderr)
 
     log_to_output(f"\r\n{result.stdout}\r\n")
     return result
@@ -1154,58 +973,26 @@ def _get_updated_env(settings: Dict[str, Any]) -> str:
     return env
 
 
-def _to_run_result_with_logging(rpc_result: jsonrpc.RpcRunResult) -> RunResult:
-    error = ""
-    if rpc_result.exception:
-        log_error(rpc_result.exception)
-        error = rpc_result.exception
-    elif rpc_result.stderr:
-        log_to_output(rpc_result.stderr)
-        error = rpc_result.stderr
-    return RunResult(rpc_result.stdout, error)
-
-
-# *****************************************************
-# Logging and notification.
-# *****************************************************
 def log_to_output(
     message: str, msg_type: lsp.MessageType = lsp.MessageType.Log
 ) -> None:
     """Logs messages to Output > Pylint channel only."""
-    LSP_SERVER.window_log_message(lsp.LogMessageParams(type=msg_type, message=message))
+    tool_server.log_to_output(message, msg_type)
 
 
 def log_error(message: str) -> None:
     """Logs messages with notification on error."""
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Error, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["onError", "onWarning", "always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Error, message=message)
-        )
+    tool_server.log_error(message)
 
 
 def log_warning(message: str) -> None:
     """Logs messages with notification on warning."""
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Warning, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["onWarning", "always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Warning, message=message)
-        )
+    tool_server.log_warning(message)
 
 
 def log_always(message: str) -> None:
     """Logs messages with notification."""
-    LSP_SERVER.window_log_message(
-        lsp.LogMessageParams(type=lsp.MessageType.Info, message=message)
-    )
-    if os.getenv("LS_SHOW_NOTIFICATION", "off") in ["always"]:
-        LSP_SERVER.window_show_message(
-            lsp.ShowMessageParams(type=lsp.MessageType.Info, message=message)
-        )
+    tool_server.log_always(message)
 
 
 # *****************************************************

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -94,9 +94,9 @@ PYLINT_CONFIG = ToolServerConfig(
             "warning": "Warning",
             "info": "Information",
         },
-        "ignorePatterns": [],
         "extraPaths": [],
     },
+    hardcoded_settings={"ignorePatterns": []},
 )
 
 tool_server = ToolServer(PYLINT_CONFIG, server=LSP_SERVER)
@@ -792,12 +792,7 @@ def _log_version_info() -> None:
 # Internal functional and settings management APIs.
 # *****************************************************
 def _get_global_defaults():
-    defaults = tool_server.get_global_defaults()
-    # ignorePatterns is always hardcoded to [] — the client resolves it
-    # before sending per-workspace settings, so the global default must
-    # never reflect user-supplied values.
-    defaults["ignorePatterns"] = []
-    return defaults
+    return tool_server.get_global_defaults()
 
 
 def _update_workspace_settings(settings):

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -62,7 +62,7 @@ from vscode_common_python_lsp import (
 
 update_environ_path()
 
-RUNNER = pathlib.Path(__file__).parent / "runner.py"
+RUNNER_SCRIPT = pathlib.Path(__file__).parent / "lsp_runner.py"
 
 MAX_WORKERS = 5
 _STDERR_ERROR_KEYWORDS = ("error", "traceback", "exception", "fatal")
@@ -83,7 +83,7 @@ PYLINT_CONFIG = ToolServerConfig(
     tool_display="Pylint",
     tool_args=["--reports=n", "--output-format=json2"],
     min_version="2.14.0",
-    runner_script=str(RUNNER),
+    runner_script=str(RUNNER_SCRIPT),
     default_settings={
         "enabled": True,
         "severity": {

--- a/bundled/tool/lsp_server.py
+++ b/bundled/tool/lsp_server.py
@@ -15,7 +15,7 @@ import sys
 import threading
 import traceback
 import types
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
 from urllib.parse import urlparse, urlunparse
 
 
@@ -100,9 +100,6 @@ PYLINT_CONFIG = ToolServerConfig(
 )
 
 tool_server = ToolServer(PYLINT_CONFIG, server=LSP_SERVER)
-
-WORKSPACE_SETTINGS = tool_server.workspace_settings
-GLOBAL_SETTINGS = tool_server.global_settings
 
 
 def _get_document_path(document: str) -> str:
@@ -225,7 +222,7 @@ def notebook_did_close(params: lsp.DidCloseNotebookDocumentParams) -> None:
 
 def _get_extra_args(document: TextDocument | None) -> list[str]:
     """Return extra pylint CLI args based on the pylint version for the workspace."""
-    code_workspace = _get_settings_by_document(document)["workspaceFS"]
+    code_workspace = tool_server.get_settings_by_document(document)["workspaceFS"]
     if VERSION_TABLE.get(code_workspace, None):
         major, minor, _ = VERSION_TABLE[code_workspace]
         if (major, minor) >= (2, 16):
@@ -255,7 +252,7 @@ def _linting_helper_notebook(notebook_uri: str) -> None:
         # that settings resolution and pylint invocation work correctly.
         # NOTE: SimpleNamespace is used here as a lightweight stand-in for
         # workspace.TextDocument. If _run_tool_on_document or
-        # _get_settings_by_document begin accessing additional attributes,
+        # tool_server.get_settings_by_document begin accessing additional attributes,
         # consider replacing this with a Protocol or TypedDict.
         nb_path = _get_document_path(notebook_uri)
         combined_doc = types.SimpleNamespace(
@@ -292,7 +289,7 @@ def _linting_helper_notebook(notebook_uri: str) -> None:
         combined_diagnostics: Sequence[lsp.Diagnostic] = []
         if result and result.stdout:
             log_to_output(f"{notebook_uri} :\r\n{result.stdout}")
-            settings = copy.deepcopy(_get_settings_by_document(combined_doc))
+            settings = copy.deepcopy(tool_server.get_settings_by_document(combined_doc))
             combined_diagnostics, _ = _parse_output(
                 result.stdout, severity=settings["severity"]
             )
@@ -370,7 +367,7 @@ def _linting_helper(document: TextDocument) -> list[lsp.Diagnostic]:
             log_to_output(f"{document.uri} :\r\n{result.stdout}")
 
             # deep copy here to prevent accidentally updating global settings.
-            settings = copy.deepcopy(_get_settings_by_document(document))
+            settings = copy.deepcopy(tool_server.get_settings_by_document(document))
             diagnostics, score = _parse_output(
                 result.stdout, severity=settings["severity"]
             )
@@ -522,7 +519,7 @@ def code_action(params: lsp.CodeActionParams) -> List[lsp.CodeAction]:
     """LSP handler for textDocument/codeAction request."""
 
     document = LSP_SERVER.workspace.get_text_document(params.text_document.uri)
-    settings = copy.deepcopy(_get_settings_by_document(document))
+    settings = copy.deepcopy(tool_server.get_settings_by_document(document))
     code_actions = []
     if not settings["enabled"]:
         return code_actions
@@ -746,7 +743,7 @@ def on_shutdown(_params: Optional[Any] = None) -> None:
 
 
 def _log_version_info() -> None:
-    for value in WORKSPACE_SETTINGS.values():
+    for value in tool_server.workspace_settings.values():
         try:
             from packaging.version import parse as parse_version
 
@@ -789,34 +786,8 @@ def _log_version_info() -> None:
 
 
 # *****************************************************
-# Internal functional and settings management APIs.
-# *****************************************************
-def _get_global_defaults():
-    return tool_server.get_global_defaults()
-
-
-def _update_workspace_settings(settings):
-    tool_server.update_workspace_settings(settings)
-
-
-def _get_settings_by_path(file_path: pathlib.Path):
-    return tool_server.get_settings_by_path(file_path)
-
-
-def _get_document_key(document: TextDocument):
-    return tool_server.get_document_key(document)
-
-
-def _get_settings_by_document(document: TextDocument | None):
-    return tool_server.get_settings_by_document(document)
-
-
-# *****************************************************
 # Internal execution APIs.
 # *****************************************************
-def get_cwd(settings: Dict[str, Any], document: Optional[TextDocument]) -> str:
-    """Returns the working directory for running the tool."""
-    return tool_server.get_cwd(settings, document)
 
 
 # pylint: disable=too-many-branches,too-many-statements
@@ -834,7 +805,7 @@ def _run_tool_on_document(
         extra_args = []
 
     # deep copy here to prevent accidentally updating global settings.
-    settings = copy.deepcopy(_get_settings_by_document(document))
+    settings = copy.deepcopy(tool_server.get_settings_by_document(document))
 
     if not settings["enabled"]:
         log_warning(f"Skipping file [Linting Disabled]: {document.path}")
@@ -857,6 +828,7 @@ def _run_tool_on_document(
     code_workspace = settings["workspaceFS"]
     cwd = tool_server.get_cwd(settings, document)
 
+    mode: Literal["path", "rpc", "module"]
     if settings["path"]:
         mode = "path"
         argv = list(settings["path"])
@@ -914,6 +886,7 @@ def _run_tool(extra_args: Sequence[str], settings: Dict[str, Any]) -> RunResult:
     code_workspace = settings["workspaceFS"]
     cwd = tool_server.get_cwd(settings, None)
 
+    mode: Literal["path", "rpc", "module"]
     if len(settings["path"]) > 0:
         mode = "path"
         argv = list(settings["path"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,7 @@ def install_bundled_libs(session):
         "py",
         "--no-deps",
         "--upgrade",
-        "vscode-common-python-lsp==0.5.1",
+        "vscode-common-python-lsp==0.6.0",
     )
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2026.5.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "^0.6.0",
+                "@vscode/common-python-lsp": "0.6.0",
                 "@vscode/python-extension": "^1.0.6",
                 "dotenv": "^17.4.0",
                 "fs-extra": "^11.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2026.5.0-dev",
             "license": "MIT",
             "dependencies": {
-                "@vscode/common-python-lsp": "0.5.1",
+                "@vscode/common-python-lsp": "^0.6.0",
                 "@vscode/python-extension": "^1.0.6",
                 "dotenv": "^17.4.0",
                 "fs-extra": "^11.3.4",
@@ -1001,6 +1001,7 @@
             "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.57.0",
                 "@typescript-eslint/types": "8.57.0",
@@ -1245,9 +1246,9 @@
             "dev": true
         },
         "node_modules/@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
+            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
             "license": "MIT",
             "dependencies": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
@@ -1748,6 +1749,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2106,6 +2108,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -2973,6 +2976,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -5912,6 +5916,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6712,6 +6717,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6874,6 +6880,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7076,6 +7083,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
             "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -7124,6 +7132,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -8166,6 +8175,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
             "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "8.57.0",
                 "@typescript-eslint/types": "8.57.0",
@@ -8301,9 +8311,9 @@
             "dev": true
         },
         "@vscode/common-python-lsp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.5.1.tgz",
-            "integrity": "sha512-iJ7s0DyE1IZ1HSoDfTBHtVuf/jlXTqtKZDeD+m922gz5JAeiVSxg89dfTxDxxwEPAZXPG4kpNUjgWiFI3wTktA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@vscode/common-python-lsp/-/common-python-lsp-0.6.0.tgz",
+            "integrity": "sha512-wabQS/YK4qlZtU2/e2JrdvuuwyjVfvoPayCcpv3n+3Ii7+4yumrP6vZo/4zsnTUlapBzckOiSyGuwA5oODJGdg==",
             "requires": {
                 "@vscode/python-environments": "https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/npm/registry/@vscode/python-environments/-/python-environments-1.0.0.tgz",
                 "@vscode/python-extension": "^1.0.6",
@@ -8681,7 +8691,8 @@
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-import-phases": {
             "version": "1.0.4",
@@ -8937,6 +8948,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
             "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -9546,6 +9558,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -11728,6 +11741,7 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
                     "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "fast-uri": "^3.0.1",
@@ -12289,7 +12303,8 @@
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
                     "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-                    "dev": true
+                    "dev": true,
+                    "peer": true
                 }
             }
         },
@@ -12405,7 +12420,8 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "uc.micro": {
             "version": "2.1.0",
@@ -12551,6 +12567,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
             "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.8",
@@ -12584,6 +12601,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "^0.6.0",
+        "@vscode/common-python-lsp": "0.6.0",
         "@vscode/python-extension": "^1.0.6",
         "dotenv": "^17.4.0",
         "fs-extra": "^11.3.4",

--- a/package.json
+++ b/package.json
@@ -228,7 +228,7 @@
         ]
     },
     "dependencies": {
-        "@vscode/common-python-lsp": "0.5.1",
+        "@vscode/common-python-lsp": "^0.6.0",
         "@vscode/python-extension": "^1.0.6",
         "dotenv": "^17.4.0",
         "fs-extra": "^11.3.4",

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -4,7 +4,13 @@
 // Extension-specific settings: ISettings type extension and legacy settings logging.
 // All shared settings resolution is handled by @vscode/common-python-lsp directly.
 
-import { IBaseSettings, getConfiguration, getWorkspaceFolders, traceWarn } from '@vscode/common-python-lsp';
+import {
+    IBaseSettings,
+    getConfiguration,
+    getWorkspaceFolders,
+    logLegacySettings as _logLegacySettings,
+    traceWarn,
+} from '@vscode/common-python-lsp';
 
 export interface ISettings extends IBaseSettings {
     enabled: boolean;
@@ -15,10 +21,11 @@ export interface ISettings extends IBaseSettings {
 }
 
 export function logLegacySettings(): void {
+    // Handle pylintEnabled separately — it has custom messaging not covered
+    // by the shared helper's simple "use X instead" pattern.
     getWorkspaceFolders().forEach((workspace) => {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
-
             const legacyPylintEnabled = legacyConfig.get<boolean>('linting.pylintEnabled', false);
             if (legacyPylintEnabled) {
                 traceWarn(`"python.linting.pylintEnabled" is deprecated. You can remove that setting.`);
@@ -30,28 +37,15 @@ export function logLegacySettings(): void {
                     `"python.linting.pylintEnabled" value for workspace ${workspace.uri.fsPath}: ${legacyPylintEnabled}`,
                 );
             }
-
-            const legacyCwd = legacyConfig.get<string>('linting.cwd');
-            if (legacyCwd) {
-                traceWarn(`"python.linting.cwd" is deprecated. Use "pylint.cwd" instead.`);
-                traceWarn(`"python.linting.cwd" value for workspace ${workspace.uri.fsPath}: ${legacyCwd}`);
-            }
-
-            const legacyArgs = legacyConfig.get<string[]>('linting.pylintArgs', []);
-            if (legacyArgs.length > 0) {
-                traceWarn(`"python.linting.pylintArgs" is deprecated. Use "pylint.args" instead.`);
-                traceWarn(`"python.linting.pylintArgs" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyArgs, null, 4)}`);
-            }
-
-            const legacyPath = legacyConfig.get<string>('linting.pylintPath', '');
-            if (legacyPath.length > 0 && legacyPath !== 'pylint') {
-                traceWarn(`"python.linting.pylintPath" is deprecated. Use "pylint.path" instead.`);
-                traceWarn(`"python.linting.pylintPath" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyPath, null, 4)}`);
-            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
     });
+
+    // Standard legacy key → new key mappings handled by the shared helper.
+    _logLegacySettings('pylint', [
+        { legacyKey: 'linting.cwd', newKey: 'cwd' },
+        { legacyKey: 'linting.pylintArgs', newKey: 'args', isArray: true },
+        { legacyKey: 'linting.pylintPath', newKey: 'path' },
+    ]);
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -27,6 +27,7 @@ export function logLegacySettings(): void {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
             const legacyPylintEnabled = legacyConfig.get<boolean>('linting.pylintEnabled', false);
+            const legacyPylintPath = legacyConfig.get<string>('linting.pylintPath', '');
             if (legacyPylintEnabled) {
                 traceWarn(`"python.linting.pylintEnabled" is deprecated. You can remove that setting.`);
                 traceWarn(
@@ -37,6 +38,11 @@ export function logLegacySettings(): void {
                     `"python.linting.pylintEnabled" value for workspace ${workspace.uri.fsPath}: ${legacyPylintEnabled}`,
                 );
             }
+            if (legacyPylintPath.length > 0 && legacyPylintPath !== 'pylint') {
+                traceWarn(`"python.linting.pylintPath" is deprecated. Use "pylint.path" instead.`);
+                traceWarn(`"python.linting.pylintPath" value for workspace ${workspace.uri.fsPath}:`);
+                traceWarn(`\n${JSON.stringify(legacyPylintPath, null, 4)}`);
+            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
@@ -46,6 +52,5 @@ export function logLegacySettings(): void {
     _logLegacySettings('pylint', [
         { legacyKey: 'linting.cwd', newKey: 'cwd' },
         { legacyKey: 'linting.pylintArgs', newKey: 'args', isArray: true },
-        { legacyKey: 'linting.pylintPath', newKey: 'path' },
     ]);
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -43,9 +43,13 @@ export function logLegacySettings(): void {
     });
 
     // Standard legacy key → new key mappings handled by the shared helper.
-    _logLegacySettings('pylint', [
-        { legacyKey: 'linting.cwd', newKey: 'cwd' },
-        { legacyKey: 'linting.pylintArgs', newKey: 'args', isArray: true },
-        { legacyKey: 'linting.pylintPath', newKey: 'path', defaultValue: 'pylint' },
-    ]);
+    try {
+        _logLegacySettings('pylint', [
+            { legacyKey: 'linting.cwd', newKey: 'cwd' },
+            { legacyKey: 'linting.pylintArgs', newKey: 'args', isArray: true },
+            { legacyKey: 'linting.pylintPath', newKey: 'path', defaultValue: 'pylint' },
+        ]);
+    } catch (err) {
+        traceWarn(`Error while logging legacy settings: ${err}`);
+    }
 }

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -27,7 +27,6 @@ export function logLegacySettings(): void {
         try {
             const legacyConfig = getConfiguration('python', workspace.uri);
             const legacyPylintEnabled = legacyConfig.get<boolean>('linting.pylintEnabled', false);
-            const legacyPylintPath = legacyConfig.get<string>('linting.pylintPath', '');
             if (legacyPylintEnabled) {
                 traceWarn(`"python.linting.pylintEnabled" is deprecated. You can remove that setting.`);
                 traceWarn(
@@ -38,11 +37,6 @@ export function logLegacySettings(): void {
                     `"python.linting.pylintEnabled" value for workspace ${workspace.uri.fsPath}: ${legacyPylintEnabled}`,
                 );
             }
-            if (legacyPylintPath.length > 0 && legacyPylintPath !== 'pylint') {
-                traceWarn(`"python.linting.pylintPath" is deprecated. Use "pylint.path" instead.`);
-                traceWarn(`"python.linting.pylintPath" value for workspace ${workspace.uri.fsPath}:`);
-                traceWarn(`\n${JSON.stringify(legacyPylintPath, null, 4)}`);
-            }
         } catch (err) {
             traceWarn(`Error while logging legacy settings: ${err}`);
         }
@@ -52,5 +46,6 @@ export function logLegacySettings(): void {
     _logLegacySettings('pylint', [
         { legacyKey: 'linting.cwd', newKey: 'cwd' },
         { legacyKey: 'linting.pylintArgs', newKey: 'args', isArray: true },
+        { legacyKey: 'linting.pylintPath', newKey: 'path', defaultValue: 'pylint' },
     ]);
 }

--- a/src/test/python_tests/test_delegated_paths.py
+++ b/src/test/python_tests/test_delegated_paths.py
@@ -7,7 +7,7 @@ and that workspace_settings/global_settings are read live (not stale aliases).
 """
 
 # pylint: disable=protected-access
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import lsp_server
 import pytest
@@ -67,7 +67,7 @@ def test_dead_shims_removed():
 
 
 def test_get_extra_args_uses_tool_server_get_settings_by_document():
-    """_get_extra_args should obtain workspace settings via tool_server.get_settings_by_document."""
+    """_get_extra_args uses tool_server.get_settings_by_document."""
     with patch.object(
         lsp_server.tool_server,
         "get_settings_by_document",

--- a/src/test/python_tests/test_delegated_paths.py
+++ b/src/test/python_tests/test_delegated_paths.py
@@ -66,16 +66,12 @@ def test_dead_shims_removed():
         assert not hasattr(lsp_server, name), f"{name} should have been removed"
 
 
-def test_tool_server_get_settings_by_document_delegated():
-    """get_settings_by_document is called on tool_server directly."""
-    mock_return = {"enabled": False, "workspaceFS": "/fake"}
+def test_get_extra_args_uses_tool_server_get_settings_by_document():
+    """_get_extra_args should obtain workspace settings via tool_server.get_settings_by_document."""
     with patch.object(
         lsp_server.tool_server,
         "get_settings_by_document",
-        return_value=mock_return,
+        return_value={"workspaceFS": "ws"},
     ) as mock_get:
-        doc = MagicMock()
-        doc.path = "/fake/file.py"
-        result = lsp_server.tool_server.get_settings_by_document(doc)
-        mock_get.assert_called_once_with(doc)
-        assert result["enabled"] is False
+        assert lsp_server._get_extra_args(None) == []
+        mock_get.assert_called_once_with(None)

--- a/src/test/python_tests/test_delegated_paths.py
+++ b/src/test/python_tests/test_delegated_paths.py
@@ -1,0 +1,80 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+"""Thin regression tests for delegated tool_server paths.
+
+Validates that key lsp_server functions correctly delegate to tool_server
+and that workspace_settings/global_settings are read live (not stale aliases).
+"""
+
+# pylint: disable=protected-access
+from unittest.mock import MagicMock, patch
+
+import lsp_server
+import pytest
+
+
+@pytest.fixture()
+def _mock_workspace_settings():
+    """Populate workspace_settings with a fake entry, clean up afterwards."""
+    ws = lsp_server.tool_server.workspace_settings
+    original = ws.copy()
+    ws.clear()
+    ws["test_ws"] = {
+        "workspaceFS": "/fake/workspace",
+        "path": [],
+        "interpreter": [],
+        "args": [],
+        "importStrategy": "useBundled",
+        "extraPaths": [],
+        "enabled": True,
+    }
+    yield ws
+    ws.clear()
+    ws.update(original)
+
+
+def test_log_version_info_reads_live_workspace_settings(
+    patched_lsp_server, _mock_workspace_settings
+):
+    """_log_version_info iterates tool_server.workspace_settings (not a stale alias)."""
+    with patch.object(lsp_server, "_run_tool") as mock_run:
+        mock_run.return_value = lsp_server.RunResult(
+            stdout="pylint 3.0.0", stderr=""
+        )
+        # Should not raise; confirms it reads the live dict
+        lsp_server._log_version_info()
+        mock_run.assert_called_once()
+
+
+def test_workspace_settings_alias_removed():
+    """WORKSPACE_SETTINGS module-level alias should no longer exist."""
+    assert not hasattr(lsp_server, "WORKSPACE_SETTINGS")
+
+
+def test_global_settings_alias_removed():
+    """GLOBAL_SETTINGS module-level alias should no longer exist."""
+    assert not hasattr(lsp_server, "GLOBAL_SETTINGS")
+
+
+def test_dead_shims_removed():
+    """Vestigial pass-through shims should no longer exist."""
+    for name in (
+        "_get_global_defaults",
+        "_update_workspace_settings",
+        "_get_settings_by_path",
+        "_get_document_key",
+        "get_cwd",
+    ):
+        assert not hasattr(lsp_server, name), f"{name} should have been removed"
+
+
+def test_tool_server_get_settings_by_document_delegated():
+    """get_settings_by_document is called on tool_server directly."""
+    with patch.object(
+        lsp_server.tool_server, "get_settings_by_document", return_value={"enabled": False, "workspaceFS": "/fake"}
+    ) as mock_get:
+        doc = MagicMock()
+        doc.path = "/fake/file.py"
+        result = lsp_server.tool_server.get_settings_by_document(doc)
+        mock_get.assert_called_once_with(doc)
+        assert result["enabled"] is False

--- a/src/test/python_tests/test_delegated_paths.py
+++ b/src/test/python_tests/test_delegated_paths.py
@@ -34,7 +34,7 @@ def _mock_workspace_settings():
 
 
 def test_log_version_info_reads_live_workspace_settings(
-    patched_lsp_server, _mock_workspace_settings
+    patched_lsp_server, _mock_workspace_settings  # pylint: disable=unused-argument
 ):
     """_log_version_info iterates tool_server.workspace_settings (not a stale alias)."""
     with patch.object(lsp_server, "_run_tool") as mock_run:
@@ -70,8 +70,10 @@ def test_dead_shims_removed():
 
 def test_tool_server_get_settings_by_document_delegated():
     """get_settings_by_document is called on tool_server directly."""
+    mock_return = {"enabled": False, "workspaceFS": "/fake"}
     with patch.object(
-        lsp_server.tool_server, "get_settings_by_document", return_value={"enabled": False, "workspaceFS": "/fake"}
+        lsp_server.tool_server, "get_settings_by_document",
+        return_value=mock_return,
     ) as mock_get:
         doc = MagicMock()
         doc.path = "/fake/file.py"

--- a/src/test/python_tests/test_delegated_paths.py
+++ b/src/test/python_tests/test_delegated_paths.py
@@ -38,9 +38,7 @@ def test_log_version_info_reads_live_workspace_settings(
 ):
     """_log_version_info iterates tool_server.workspace_settings (not a stale alias)."""
     with patch.object(lsp_server, "_run_tool") as mock_run:
-        mock_run.return_value = lsp_server.RunResult(
-            stdout="pylint 3.0.0", stderr=""
-        )
+        mock_run.return_value = lsp_server.RunResult(stdout="pylint 3.0.0", stderr="")
         # Should not raise; confirms it reads the live dict
         lsp_server._log_version_info()
         mock_run.assert_called_once()
@@ -72,7 +70,8 @@ def test_tool_server_get_settings_by_document_delegated():
     """get_settings_by_document is called on tool_server directly."""
     mock_return = {"enabled": False, "workspaceFS": "/fake"}
     with patch.object(
-        lsp_server.tool_server, "get_settings_by_document",
+        lsp_server.tool_server,
+        "get_settings_by_document",
         return_value=mock_return,
     ) as mock_get:
         doc = MagicMock()

--- a/src/test/python_tests/test_diagnostic_regex.py
+++ b/src/test/python_tests/test_diagnostic_regex.py
@@ -15,7 +15,7 @@ import lsp_server
 from lsp_server import _get_severity, _parse_output
 
 # ---------------------------------------------------------------------------
-# Default severity mapping (matches _get_global_defaults in lsp_server.py)
+# Default severity mapping (matches tool_server.get_global_defaults in lsp_server.py)
 # ---------------------------------------------------------------------------
 DEFAULT_SEVERITY = {
     "convention": "Information",

--- a/src/test/python_tests/test_get_cwd.py
+++ b/src/test/python_tests/test_get_cwd.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-"""Unit tests for the get_cwd() helper in lsp_server."""
+"""Unit tests for tool_server.get_cwd() delegated via lsp_server."""
 
 import os
 import types
@@ -31,13 +31,13 @@ def _make_doc(path):
 def test_no_cwd_no_document_returns_workspace():
     """When neither cwd nor document is provided, return workspaceFS."""
     settings = _make_settings()
-    assert lsp_server.get_cwd(settings, None) == WORKSPACE
+    assert lsp_server.tool_server.get_cwd(settings, None) == WORKSPACE
 
 
 def test_plain_cwd_no_document_returned_unchanged():
     """A cwd without variables is returned as-is even without a document."""
     settings = _make_settings(cwd="/custom/path")
-    assert lsp_server.get_cwd(settings, None) == "/custom/path"
+    assert lsp_server.tool_server.get_cwd(settings, None) == "/custom/path"
 
 
 def test_file_variable_no_document_falls_back_to_workspace():
@@ -52,14 +52,14 @@ def test_file_variable_no_document_falls_back_to_workspace():
         "${fileWorkspaceFolder}",
     ]:
         settings = _make_settings(cwd=token + "/extra")
-        assert lsp_server.get_cwd(settings, None) == WORKSPACE, f"Failed for {token}"
+        assert lsp_server.tool_server.get_cwd(settings, None) == WORKSPACE, f"Failed for {token}"
 
 
 def test_relative_file_variable_no_document_falls_back_to_workspace():
     """Unresolvable ${relativeFile*} variable with no document falls back to workspaceFS."""
     for token in ["${relativeFile}", "${relativeFileDirname}"]:
         settings = _make_settings(cwd=token)
-        assert lsp_server.get_cwd(settings, None) == WORKSPACE, f"Failed for {token}"
+        assert lsp_server.tool_server.get_cwd(settings, None) == WORKSPACE, f"Failed for {token}"
 
 
 # ---------------------------------------------------------------------------
@@ -95,30 +95,30 @@ DOC = _make_doc(DOC_PATH)
 def test_single_variable_resolved(token, expected):
     """Each VS Code variable token resolves to its expected value."""
     settings = _make_settings(cwd=token)
-    assert lsp_server.get_cwd(settings, DOC) == expected
+    assert lsp_server.tool_server.get_cwd(settings, DOC) == expected
 
 
 def test_composite_pattern_resolved():
     """Variables embedded inside a longer path are substituted correctly."""
     settings = _make_settings(cwd="${fileDirname}/subdir")
-    assert lsp_server.get_cwd(settings, DOC) == "/home/user/myproject/src/subdir"
+    assert lsp_server.tool_server.get_cwd(settings, DOC) == "/home/user/myproject/src/subdir"
 
 
 def test_multiple_variables_in_one_cwd():
     """Multiple different variables in the same cwd string are all resolved."""
     settings = _make_settings(cwd="${fileDirname}/${fileBasename}")
-    result = lsp_server.get_cwd(settings, DOC)
+    result = lsp_server.tool_server.get_cwd(settings, DOC)
     assert result == "/home/user/myproject/src/foo.py"
 
 
 def test_no_variable_in_cwd_unchanged():
     """A cwd with no variables is returned unchanged even when a document exists."""
     settings = _make_settings(cwd="/static/path")
-    assert lsp_server.get_cwd(settings, DOC) == "/static/path"
+    assert lsp_server.tool_server.get_cwd(settings, DOC) == "/static/path"
 
 
 def test_document_with_no_path_falls_back_to_workspace():
     """A document object whose path is falsy triggers the fallback."""
     doc = types.SimpleNamespace(path="")
     settings = _make_settings(cwd="${fileDirname}")
-    assert lsp_server.get_cwd(settings, doc) == WORKSPACE
+    assert lsp_server.tool_server.get_cwd(settings, doc) == WORKSPACE

--- a/src/test/python_tests/test_get_cwd.py
+++ b/src/test/python_tests/test_get_cwd.py
@@ -52,14 +52,18 @@ def test_file_variable_no_document_falls_back_to_workspace():
         "${fileWorkspaceFolder}",
     ]:
         settings = _make_settings(cwd=token + "/extra")
-        assert lsp_server.tool_server.get_cwd(settings, None) == WORKSPACE, f"Failed for {token}"
+        assert (
+            lsp_server.tool_server.get_cwd(settings, None) == WORKSPACE
+        ), f"Failed for {token}"
 
 
 def test_relative_file_variable_no_document_falls_back_to_workspace():
     """Unresolvable ${relativeFile*} variable with no document falls back to workspaceFS."""
     for token in ["${relativeFile}", "${relativeFileDirname}"]:
         settings = _make_settings(cwd=token)
-        assert lsp_server.tool_server.get_cwd(settings, None) == WORKSPACE, f"Failed for {token}"
+        assert (
+            lsp_server.tool_server.get_cwd(settings, None) == WORKSPACE
+        ), f"Failed for {token}"
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +105,10 @@ def test_single_variable_resolved(token, expected):
 def test_composite_pattern_resolved():
     """Variables embedded inside a longer path are substituted correctly."""
     settings = _make_settings(cwd="${fileDirname}/subdir")
-    assert lsp_server.tool_server.get_cwd(settings, DOC) == "/home/user/myproject/src/subdir"
+    assert (
+        lsp_server.tool_server.get_cwd(settings, DOC)
+        == "/home/user/myproject/src/subdir"
+    )
 
 
 def test_multiple_variables_in_one_cwd():

--- a/src/test/python_tests/test_global_defaults.py
+++ b/src/test/python_tests/test_global_defaults.py
@@ -49,5 +49,7 @@ def _with_global_settings(overrides, func):
 )
 def test_global_defaults_setting(overrides, key, expected):
     """Each global setting is correctly read or defaults when absent."""
-    result = _with_global_settings(overrides, lsp_server.tool_server.get_global_defaults)
+    result = _with_global_settings(
+        overrides, lsp_server.tool_server.get_global_defaults
+    )
     assert result[key] == expected

--- a/src/test/python_tests/test_global_defaults.py
+++ b/src/test/python_tests/test_global_defaults.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-"""Unit tests for _get_global_defaults() in lsp_server.
+"""Unit tests for get_global_defaults() via tool_server in lsp_server.
 
 Validates that global settings are correctly read (or hardcoded) in the
 pylint extension.  Mock setup is provided by conftest.py (setup_lsp_mocks).
@@ -12,15 +12,15 @@ import pytest
 
 
 def _with_global_settings(overrides, func):
-    """Run *func* with GLOBAL_SETTINGS temporarily set to *overrides*."""
-    original = lsp_server.GLOBAL_SETTINGS.copy()
+    """Run *func* with tool_server.global_settings temporarily set to *overrides*."""
+    original = lsp_server.tool_server.global_settings.copy()
     try:
-        lsp_server.GLOBAL_SETTINGS.clear()
-        lsp_server.GLOBAL_SETTINGS.update(overrides)
+        lsp_server.tool_server.global_settings.clear()
+        lsp_server.tool_server.global_settings.update(overrides)
         return func()
     finally:
-        lsp_server.GLOBAL_SETTINGS.clear()
-        lsp_server.GLOBAL_SETTINGS.update(original)
+        lsp_server.tool_server.global_settings.clear()
+        lsp_server.tool_server.global_settings.update(original)
 
 
 @pytest.mark.parametrize(
@@ -49,5 +49,5 @@ def _with_global_settings(overrides, func):
 )
 def test_global_defaults_setting(overrides, key, expected):
     """Each global setting is correctly read or defaults when absent."""
-    result = _with_global_settings(overrides, lsp_server._get_global_defaults)
+    result = _with_global_settings(overrides, lsp_server.tool_server.get_global_defaults)
     assert result[key] == expected


### PR DESCRIPTION
## Summary
Reduce code duplication between this extension and the shared package \@vscode/common-python-lsp\ (\scode-common-python-lsp\).

### Changes
- **\src/common/settings.ts\**: Use shared \logLegacySettings()\ instead of inline legacy-setting migration warnings
- **\undled/tool/lsp_server.py\**: Migrate to \ToolServer\/\ToolServerConfig\ from the shared package — replaces hand-rolled settings management, CWD resolution, tool execution, logging, and lifecycle handlers with shared implementations
- **Tests**: Updated existing tests (\	est_global_defaults.py\, \	est_get_cwd.py\, \	est_diagnostic_regex.py\) to reference \	ool_server\ directly; added \	est_delegated_paths.py\ with regression tests for the delegated paths

### Impact
- Significant reduction in duplicated code across all extension repos
- Tool-specific logic (formatting, code actions, daemon management, etc.) remains local
- No behavioral changes — all existing functionality preserved
- Pinned \@vscode/common-python-lsp\ to exact \