### PR TITLE
Fix Python 3.14 test process cleanup

### DIFF
--- a/src/test/python_tests/lsp_test_client/session.py
+++ b/src/test/python_tests/lsp_test_client/session.py
@@ -17,7 +17,7 @@ from pyls_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter
 from . import defaults
 from .constants import PROJECT_ROOT
 
-LSP_EXIT_TIMEOUT = 5000
+LSP_EXIT_TIMEOUT = 5
 
 
 PUBLISH_DIAGNOSTICS = "textDocument/publishDiagnostics"
@@ -59,8 +59,8 @@ class LspSession(MethodDispatcher):
             shell="WITH_COVERAGE" in os.environ,
         )
 
-        self._writer = JsonRpcStreamWriter(os.fdopen(self._sub.stdin.fileno(), "wb"))
-        self._reader = JsonRpcStreamReader(os.fdopen(self._sub.stdout.fileno(), "rb"))
+        self._writer = JsonRpcStreamWriter(self._sub.stdin)
+        self._reader = JsonRpcStreamReader(self._sub.stdout)
 
         dispatcher = {
             PUBLISH_DIAGNOSTICS: self._publish_diagnostics,


### PR DESCRIPTION
## Summary

- use the existing `Popen` stdin/stdout streams instead of creating duplicate owners for the same file descriptors
- change the language-server exit timeout from 5,000 seconds to 5 seconds
- prevent intermittent Windows/Python 3.14 test hangs and bad-file-descriptor warnings

## Validation

- `python -m nox --session lint`
- Python 3.14: 121 Python tests passed
- Python 3.14: 20 build tests passed